### PR TITLE
Fix path string in regroup_reds_dataset

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,6 @@
 name: Python Lint
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/scripts/regroup_reds_dataset.py
+++ b/scripts/regroup_reds_dataset.py
@@ -18,8 +18,9 @@ def regroup_reds_dataset(train_path, val_path):
     # move the validation data to the train folder
     val_folders = glob.glob(os.path.join(val_path, '*'))
     for folder in val_folders:
-        new_folder_idx = int(folder.split(' / ')[-1]) + 240
-        os.system(f'cp -r {folder} {os.path.join(train_path, new_folder_idx)}')
+        new_folder_idx = int(folder.split('/')[-1]) + 240
+        os.system(
+            f'cp -r {folder} {os.path.join(train_path, str(new_folder_idx))}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are two fixes in this commit. 1. Split path with the separator "/" instead of " / "; 2. Join a string and an integer