### PR TITLE
Fix the bug in video_base_model.py

### DIFF
--- a/basicsr/models/video_base_model.py
+++ b/basicsr/models/video_base_model.py
@@ -34,9 +34,10 @@ class VideoBaseModel(SRModel):
                     len(self.opt['val']['metrics']),
                     dtype=torch.float32,
                     device='cuda')
+        rank, world_size = get_dist_info()
+        if with_metrics:
             for _, tensor in self.metric_results.items():
                 tensor.zero_()
-        rank, world_size = get_dist_info()
         # record all frames (border and center frames)
         if rank == 0:
             pbar = tqdm(total=len(dataset), unit='frame')

--- a/basicsr/models/video_base_model.py
+++ b/basicsr/models/video_base_model.py
@@ -34,7 +34,6 @@ class VideoBaseModel(SRModel):
                     len(self.opt['val']['metrics']),
                     dtype=torch.float32,
                     device='cuda')
-            
             for _, tensor in self.metric_results.items():
                 tensor.zero_()
         rank, world_size = get_dist_info()

--- a/basicsr/models/video_base_model.py
+++ b/basicsr/models/video_base_model.py
@@ -34,10 +34,10 @@ class VideoBaseModel(SRModel):
                     len(self.opt['val']['metrics']),
                     dtype=torch.float32,
                     device='cuda')
-
+            
+            for _, tensor in self.metric_results.items():
+                tensor.zero_()
         rank, world_size = get_dist_info()
-        for _, tensor in self.metric_results.items():
-            tensor.zero_()
         # record all frames (border and center frames)
         if rank == 0:
             pbar = tqdm(total=len(dataset), unit='frame')


### PR DESCRIPTION
When the metrics is None in the yaml files, old video_base_model.py will make the self.metric_results.items to zero but there is no this tensor actually. So this loop should be in the judgement of whether there are metric.