### PR TITLE
Support Python 3.5 by removing uses of f-strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ wandb/*
 tmp/*
 
 .vscode
+.idea
 
 # ignored files
 version.py

--- a/basicsr/data/__init__.py
+++ b/basicsr/data/__init__.py
@@ -21,7 +21,7 @@ dataset_filenames = [
 ]
 # import all the dataset modules
 _dataset_modules = [
-    importlib.import_module(f'basicsr.data.{file_name}')
+    importlib.import_module('basicsr.data.%s' % file_name)
     for file_name in dataset_filenames
 ]
 
@@ -42,14 +42,13 @@ def create_dataset(dataset_opt):
         if dataset_cls is not None:
             break
     if dataset_cls is None:
-        raise ValueError(f'Dataset {dataset_type} is not found.')
+        raise ValueError('Dataset %s is not found.' % dataset_type)
 
     dataset = dataset_cls(dataset_opt)
 
     logger = get_root_logger()
     logger.info(
-        f'Dataset {dataset.__class__.__name__} - {dataset_opt["name"]} '
-        'is created.')
+        'Dataset %s - %s is created.' % (dataset.__class__.__name__, dataset_opt["name"]))
     return dataset
 
 
@@ -100,7 +99,7 @@ def create_dataloader(dataset,
         dataloader_args = dict(
             dataset=dataset, batch_size=1, shuffle=False, num_workers=0)
     else:
-        raise ValueError(f'Wrong dataset phase: {phase}. '
+        raise ValueError('Wrong dataset phase: %s. ' % phase +
                          "Supported ones are 'train', 'val' and 'test'.")
 
     dataloader_args['pin_memory'] = dataset_opt.get('pin_memory', False)
@@ -109,8 +108,8 @@ def create_dataloader(dataset,
     if prefetch_mode == 'cpu':  # CPUPrefetcher
         num_prefetch_queue = dataset_opt.get('num_prefetch_queue', 1)
         logger = get_root_logger()
-        logger.info(f'Use {prefetch_mode} prefetch dataloader: '
-                    f'num_prefetch_queue = {num_prefetch_queue}')
+        logger.info('Use %s prefetch dataloader: ' % prefetch_mode +
+                    'num_prefetch_queue = %s' % num_prefetch_queue)
         return PrefetchDataLoader(
             num_prefetch_queue=num_prefetch_queue, **dataloader_args)
     else:

--- a/basicsr/data/data_util.py
+++ b/basicsr/data/data_util.py
@@ -57,7 +57,7 @@ def generate_frame_indices(crt_idx,
     """
     assert num_frames % 2 == 1, 'num_frames should be an odd number.'
     assert padding in ('replicate', 'reflection', 'reflection_circle',
-                       'circle'), f'Wrong padding mode: {padding}.'
+                       'circle'), 'Wrong padding mode: %s.' % padding
 
     max_frame_num = max_frame_num - 1  # start from 0
     num_pad = num_frames // 2
@@ -125,18 +125,18 @@ def paired_paths_from_lmdb(folders, keys):
     """
     assert len(folders) == 2, (
         'The len of folders should be 2 with [input_folder, gt_folder]. '
-        f'But got {len(folders)}')
+        'But got %d' % len(folders))
     assert len(keys) == 2, (
         'The len of keys should be 2 with [input_key, gt_key]. '
-        f'But got {len(keys)}')
+        'But got %d' % len(keys))
     input_folder, gt_folder = folders
     input_key, gt_key = keys
 
     if not (input_folder.endswith('.lmdb') and gt_folder.endswith('.lmdb')):
         raise ValueError(
-            f'{input_key} folder and {gt_key} folder should both in lmdb '
-            f'formats. But received {input_key}: {input_folder}; '
-            f'{gt_key}: {gt_folder}')
+            '%s folder and %s folder should both in lmdb ' % (input_key, gt_key) +
+            'formats. But received %s: %s; ' % (input_key, input_folder) +
+            '%s: %s' % (gt_key, gt_folder))
     # ensure that the two meta_info files are the same
     with open(osp.join(input_folder, 'meta_info.txt')) as fin:
         input_lmdb_keys = [line.split('.')[0] for line in fin]
@@ -144,13 +144,13 @@ def paired_paths_from_lmdb(folders, keys):
         gt_lmdb_keys = [line.split('.')[0] for line in fin]
     if set(input_lmdb_keys) != set(gt_lmdb_keys):
         raise ValueError(
-            f'Keys in {input_key}_folder and {gt_key}_folder are different.')
+            'Keys in %s_folder and %s_folder are different.' % (input_key, gt_key))
     else:
         paths = []
         for lmdb_key in sorted(input_lmdb_keys):
             paths.append(
-                dict([(f'{input_key}_path', lmdb_key),
-                      (f'{gt_key}_path', lmdb_key)]))
+                dict([('%s_path' % input_key, lmdb_key),
+                      ('%s_path' % gt_key, lmdb_key)]))
         return paths
 
 
@@ -182,10 +182,10 @@ def paired_paths_from_meta_info_file(folders, keys, meta_info_file,
     """
     assert len(folders) == 2, (
         'The len of folders should be 2 with [input_folder, gt_folder]. '
-        f'But got {len(folders)}')
+        'But got %d' % len(folders))
     assert len(keys) == 2, (
         'The len of keys should be 2 with [input_key, gt_key]. '
-        f'But got {len(keys)}')
+        'But got %d' % len(keys))
     input_folder, gt_folder = folders
     input_key, gt_key = keys
 
@@ -195,12 +195,12 @@ def paired_paths_from_meta_info_file(folders, keys, meta_info_file,
     paths = []
     for gt_name in gt_names:
         basename, ext = osp.splitext(osp.basename(gt_name))
-        input_name = f'{filename_tmpl.format(basename)}{ext}'
+        input_name = filename_tmpl.format(basename) + ext
         input_path = osp.join(input_folder, input_name)
         gt_path = osp.join(gt_folder, gt_name)
         paths.append(
-            dict([(f'{input_key}_path', input_path),
-                  (f'{gt_key}_path', gt_path)]))
+            dict([('%s_path' % input_key, input_path),
+                  ('%s_path' % gt_key, gt_path)]))
     return paths
 
 
@@ -221,29 +221,29 @@ def paired_paths_from_folder(folders, keys, filename_tmpl):
     """
     assert len(folders) == 2, (
         'The len of folders should be 2 with [input_folder, gt_folder]. '
-        f'But got {len(folders)}')
+        'But got %d' % len(folders))
     assert len(keys) == 2, (
         'The len of keys should be 2 with [input_key, gt_key]. '
-        f'But got {len(keys)}')
+        'But got %d' % len(keys))
     input_folder, gt_folder = folders
     input_key, gt_key = keys
 
     input_paths = list(scandir(input_folder))
     gt_paths = list(scandir(gt_folder))
     assert len(input_paths) == len(gt_paths), (
-        f'{input_key} and {gt_key} datasets have different number of images: '
-        f'{len(input_paths)}, {len(gt_paths)}.')
+        '%s and %s datasets have different number of images: ' % (input_key, gt_key) +
+        '%d, %d.' % (len(input_paths), len(gt_paths)))
     paths = []
     for gt_path in gt_paths:
         basename, ext = osp.splitext(osp.basename(gt_path))
-        input_name = f'{filename_tmpl.format(basename)}{ext}'
+        input_name = filename_tmpl.format(basename) + ext
         input_path = osp.join(input_folder, input_name)
-        assert input_name in input_paths, (f'{input_name} is not in '
-                                           f'{input_key}_paths.')
+        assert input_name in input_paths, ('%s is not in ' % input_name +
+                                           '%s_paths.' % input_key)
         gt_path = osp.join(gt_folder, gt_path)
         paths.append(
-            dict([(f'{input_key}_path', input_path),
-                  (f'{gt_key}_path', gt_path)]))
+            dict([('%s_path' % input_key, input_path),
+                  ('%s_path' % gt_key, gt_path)]))
     return paths
 
 
@@ -272,7 +272,7 @@ def paths_from_lmdb(folder):
         list[str]: Returned path list.
     """
     if not folder.endswith('.lmdb'):
-        raise ValueError(f'Folder {folder}folder should in lmdb format.')
+        raise ValueError('Folder %s should in lmdb format.' % folder)
     with open(osp.join(folder, 'meta_info.txt')) as fin:
         paths = [line.split('.')[0] for line in fin]
     return paths
@@ -308,8 +308,8 @@ def duf_downsample(x, kernel_size=13, scale=4):
     Returns:
         Tensor: DUF downsampled frames.
     """
-    assert scale in (2, 3,
-                     4), f'Only support scale (2, 3, 4), but got {scale}.'
+    assert scale in (2, 3, 4), \
+        'Only support scale (2, 3, 4), but got %d.' % scale
 
     squeeze_flag = False
     if x.ndim == 4:

--- a/basicsr/data/ffhq_dataset.py
+++ b/basicsr/data/ffhq_dataset.py
@@ -34,13 +34,13 @@ class FFHQDataset(data.Dataset):
             self.io_backend_opt['db_paths'] = self.gt_folder
             if not self.gt_folder.endswith('.lmdb'):
                 raise ValueError("'dataroot_gt' should end with '.lmdb', "
-                                 f'but received {self.gt_folder}')
+                                 'but received %s' % self.gt_folder)
             with open(osp.join(self.gt_folder, 'meta_info.txt')) as fin:
                 self.paths = [line.split('.')[0] for line in fin]
         else:
             # FFHQ has 70000 images in total
             self.paths = [
-                osp.join(self.gt_folder, f'{v:08d}.png') for v in range(70000)
+                osp.join(self.gt_folder, '{:08d}.png'.format(v)) for v in range(70000)
             ]
 
     def __getitem__(self, index):

--- a/basicsr/data/transforms.py
+++ b/basicsr/data/transforms.py
@@ -18,7 +18,7 @@ def mod_crop(img, scale):
         h_remainder, w_remainder = h % scale, w % scale
         img = img[:h - h_remainder, :w - w_remainder, ...]
     else:
-        raise ValueError(f'Wrong img ndim: {img.ndim}.')
+        raise ValueError('Wrong img ndim: %d.' % img.ndim)
     return img
 
 
@@ -54,12 +54,12 @@ def paired_random_crop(img_gts, img_lqs, gt_patch_size, scale, gt_path):
 
     if h_gt != h_lq * scale or w_gt != w_lq * scale:
         raise ValueError(
-            f'Scale mismatches. GT ({h_gt}, {w_gt}) is not {scale}x ',
-            f'multiplication of LQ ({h_lq}, {w_lq}).')
+            'Scale mismatches. GT (%d, %d) is not %dx ' % (h_gt, w_gt, scale),
+            'multiplication of LQ (%d, %d).' % (h_lq, w_lq))
     if h_lq < lq_patch_size or w_lq < lq_patch_size:
-        raise ValueError(f'LQ ({h_lq}, {w_lq}) is smaller than patch size '
-                         f'({lq_patch_size}, {lq_patch_size}). '
-                         f'Please remove {gt_path}.')
+        raise ValueError('LQ (%d, %d) is smaller than patch size ' % (h_lq, w_lq) +
+                         '(%d, %d). ' % (lq_patch_size, lq_patch_size) +
+                         'Please remove %s.' % gt_path)
 
     # randomly choose top and left coordinates for lq patch
     top = random.randint(0, h_lq - lq_patch_size)

--- a/basicsr/data/video_test_dataset.py
+++ b/basicsr/data/video_test_dataset.py
@@ -60,7 +60,7 @@ class VideoTestDataset(data.Dataset):
             'type'] != 'lmdb', 'No need to use lmdb during validation/test.'
 
         logger = get_root_logger()
-        logger.info(f'Generate data info for VideoTestDataset - {opt["name"]}')
+        logger.info('Generate data info for VideoTestDataset - %s' % opt["name"])
         self.imgs_lq, self.imgs_gt = {}, {}
         if 'meta_info_file' in opt:
             with open(opt['meta_info_file'], 'r') as fin:
@@ -87,14 +87,14 @@ class VideoTestDataset(data.Dataset):
 
                 max_idx = len(img_paths_lq)
                 assert max_idx == len(img_paths_gt), (
-                    f'Different number of images in lq ({max_idx})'
-                    f' and gt folders ({len(img_paths_gt)})')
+                    'Different number of images in lq (%d)' % max_idx +
+                    ' and gt folders (%d)' % len(img_paths_gt))
 
                 self.data_info['lq_path'].extend(img_paths_lq)
                 self.data_info['gt_path'].extend(img_paths_gt)
                 self.data_info['folder'].extend([subfolder_name] * max_idx)
                 for i in range(max_idx):
-                    self.data_info['idx'].append(f'{i}/{max_idx}')
+                    self.data_info['idx'].append('%d/%d' % (i, max_idx))
                 border_l = [0] * max_idx
                 for i in range(self.opt['num_frame'] // 2):
                     border_l[i] = 1
@@ -104,7 +104,7 @@ class VideoTestDataset(data.Dataset):
                 # cache data or save the frame list
                 if self.cache_data:
                     logger.info(
-                        f'Cache {subfolder_name} for VideoTestDataset...')
+                        'Cache %s for VideoTestDataset...' % subfolder_name)
                     self.imgs_lq[subfolder_name] = read_img_seq(img_paths_lq)
                     self.imgs_gt[subfolder_name] = read_img_seq(img_paths_gt)
                 else:
@@ -112,7 +112,7 @@ class VideoTestDataset(data.Dataset):
                     self.imgs_gt[subfolder_name] = img_paths_gt
         else:
             raise ValueError(
-                f'Non-supported video test dataset: {type(opt["name"])}')
+                'Non-supported video test dataset: %s' % type(opt["name"]))
 
     def __getitem__(self, index):
         folder = self.data_info['folder'][index]
@@ -193,19 +193,19 @@ class VideoTestVimeo90KDataset(data.Dataset):
             'type'] != 'lmdb', 'No need to use lmdb during validation/test.'
 
         logger = get_root_logger()
-        logger.info(f'Generate data info for VideoTestDataset - {opt["name"]}')
+        logger.info('Generate data info for VideoTestDataset - %s' % opt["name"])
         with open(opt['meta_info_file'], 'r') as fin:
             subfolders = [line.split(' ')[0] for line in fin]
         for idx, subfolder in enumerate(subfolders):
             gt_path = osp.join(self.gt_root, subfolder, 'im4.png')
             self.data_info['gt_path'].append(gt_path)
             lq_paths = [
-                osp.join(self.lq_root, subfolder, f'im{i}.png')
+                osp.join(self.lq_root, subfolder, 'im%d.png' % i)
                 for i in neighbor_list
             ]
             self.data_info['lq_path'].append(lq_paths)
             self.data_info['folder'].append('vimeo90k')
-            self.data_info['idx'].append(f'{idx}/{len(subfolders)}')
+            self.data_info['idx'].append('%d/%d' % (idx, len(subfolders)))
             self.data_info['border'].append(0)
 
     def __getitem__(self, index):

--- a/basicsr/data/vimeo90k_dataset.py
+++ b/basicsr/data/vimeo90k_dataset.py
@@ -73,7 +73,7 @@ class Vimeo90KDataset(data.Dataset):
         # temporal augmentation configs
         self.random_reverse = opt['random_reverse']
         logger = get_root_logger()
-        logger.info(f'Random reverse is {self.random_reverse}.')
+        logger.info('Random reverse is %s.' % self.random_reverse)
 
     def __getitem__(self, index):
         if self.file_client is None:
@@ -91,7 +91,7 @@ class Vimeo90KDataset(data.Dataset):
 
         # get the GT frame (im4.png)
         if self.is_lmdb:
-            img_gt_path = f'{key}/im4'
+            img_gt_path = '%s/im4' % key
         else:
             img_gt_path = self.gt_root / clip / seq / 'im4.png'
         img_bytes = self.file_client.get(img_gt_path, 'gt')
@@ -101,9 +101,9 @@ class Vimeo90KDataset(data.Dataset):
         img_lqs = []
         for neighbor in self.neighbor_list:
             if self.is_lmdb:
-                img_lq_path = f'{clip}/{seq}/im{neighbor}'
+                img_lq_path = '%s/%s/im%s' % (clip, seq, neighbor)
             else:
-                img_lq_path = self.lq_root / clip / seq / f'im{neighbor}.png'
+                img_lq_path = self.lq_root / clip / seq / 'im%s.png' % neighbor
             img_bytes = self.file_client.get(img_lq_path, 'lq')
             img_lq = imfrombytes(img_bytes, float32=True)
             img_lqs.append(img_lq)

--- a/basicsr/metrics/fid.py
+++ b/basicsr/metrics/fid.py
@@ -91,7 +91,7 @@ def calculate_fid(mu1, sigma1, mu2, sigma2, eps=1e-6):
     if np.iscomplexobj(cov_sqrt):
         if not np.allclose(np.diagonal(cov_sqrt).imag, 0, atol=1e-3):
             m = np.max(np.abs(cov_sqrt.imag))
-            raise ValueError(f'Imaginary component {m}')
+            raise ValueError('Imaginary component %s' % m)
         cov_sqrt = cov_sqrt.real
 
     mean_diff = mu1 - mu2

--- a/basicsr/metrics/metric_util.py
+++ b/basicsr/metrics/metric_util.py
@@ -22,7 +22,7 @@ def reorder_image(img, input_order='HWC'):
 
     if input_order not in ['HWC', 'CHW']:
         raise ValueError(
-            f'Wrong input_order {input_order}. Supported input_orders are '
+            'Wrong input_order %s. Supported input_orders are ' % input_order +
             "'HWC' and 'CHW'")
     if len(img.shape) == 2:
         img = img[..., None]

--- a/basicsr/metrics/psnr_ssim.py
+++ b/basicsr/metrics/psnr_ssim.py
@@ -27,10 +27,10 @@ def calculate_psnr(img1,
     """
 
     assert img1.shape == img2.shape, (
-        f'Image shapes are differnet: {img1.shape}, {img2.shape}.')
+        'Image shapes are differnet: %s, %s.' % (img1.shape, img2.shape))
     if input_order not in ['HWC', 'CHW']:
         raise ValueError(
-            f'Wrong input_order {input_order}. Supported input_orders are '
+            'Wrong input_order %s. Supported input_orders are ' % input_order +
             '"HWC" and "CHW"')
     img1 = reorder_image(img1, input_order=input_order)
     img2 = reorder_image(img2, input_order=input_order)
@@ -117,10 +117,10 @@ def calculate_ssim(img1,
     """
 
     assert img1.shape == img2.shape, (
-        f'Image shapes are differnet: {img1.shape}, {img2.shape}.')
+        'Image shapes are differnet: %s, %s.' % (img1.shape, img2.shape))
     if input_order not in ['HWC', 'CHW']:
         raise ValueError(
-            f'Wrong input_order {input_order}. Supported input_orders are '
+            'Wrong input_order %s. Supported input_orders are ' % input_order +
             '"HWC" and "CHW"')
     img1 = reorder_image(img1, input_order=input_order)
     img2 = reorder_image(img2, input_order=input_order)

--- a/basicsr/models/__init__.py
+++ b/basicsr/models/__init__.py
@@ -13,7 +13,7 @@ model_filenames = [
 ]
 # import all the model modules
 _model_modules = [
-    importlib.import_module(f'basicsr.models.{file_name}')
+    importlib.import_module('basicsr.models.%s' % file_name)
     for file_name in model_filenames
 ]
 
@@ -33,10 +33,10 @@ def create_model(opt):
         if model_cls is not None:
             break
     if model_cls is None:
-        raise ValueError(f'Model {model_type} is not found.')
+        raise ValueError('Model %s is not found.' % model_type)
 
     model = model_cls(opt)
 
     logger = get_root_logger()
-    logger.info(f'Model [{model.__class__.__name__}] is created.')
+    logger.info('Model [%s] is created.' % model.__class__.__name__)
     return model

--- a/basicsr/models/archs/__init__.py
+++ b/basicsr/models/archs/__init__.py
@@ -13,7 +13,7 @@ arch_filenames = [
 ]
 # import all the arch modules
 _arch_modules = [
-    importlib.import_module(f'basicsr.models.archs.{file_name}')
+    importlib.import_module('basicsr.models.archs.%s' % file_name)
     for file_name in arch_filenames
 ]
 
@@ -36,7 +36,7 @@ def dynamic_instantiation(modules, cls_type, opt):
         if cls_ is not None:
             break
     if cls_ is None:
-        raise ValueError(f'{cls_type} is not found.')
+        raise ValueError('%s is not found.' % cls_type)
     return cls_(**opt)
 
 

--- a/basicsr/models/archs/arch_util.py
+++ b/basicsr/models/archs/arch_util.py
@@ -113,7 +113,7 @@ class Upsample(nn.Sequential):
             m.append(nn.Conv2d(num_feat, 9 * num_feat, 3, 1, 1))
             m.append(nn.PixelShuffle(3))
         else:
-            raise ValueError(f'scale {scale} is not supported. '
+            raise ValueError('scale %d is not supported. ' % scale +
                              'Supported scales: 2^n and 3.')
         super(Upsample, self).__init__(*m)
 
@@ -194,7 +194,7 @@ def resize_flow(flow,
         output_h, output_w = sizes[0], sizes[1]
     else:
         raise ValueError(
-            f'Size type should be ratio or shape, but got type {size_type}.')
+            'Size type should be ratio or shape, but got type %s.' % size_type)
 
     input_flow = flow.clone()
     ratio_h = output_h / flow_h
@@ -250,7 +250,7 @@ class DCNv2Pack(ModulatedDeformConvPack):
         if offset_absmean > 50:
             logger = get_root_logger()
             logger.warning(
-                f'Offset abs mean is {offset_absmean}, larger than 50.')
+                'Offset abs mean is %d, larger than 50.' % offset_absmean)
 
         return modulated_deform_conv(x, offset, mask, self.weight, self.bias,
                                      self.stride, self.padding, self.dilation,

--- a/basicsr/models/archs/dfdnet_arch.py
+++ b/basicsr/models/archs/dfdnet_arch.py
@@ -84,7 +84,7 @@ class DFDNet(nn.Module):
         self.attn_blocks = nn.ModuleDict()
         for idx, feat_size in enumerate(self.feature_sizes):
             for name in self.parts:
-                self.attn_blocks[f'{name}_{feat_size}'] = AttentionBlock(
+                self.attn_blocks['%s_%d' % (name, feat_size)] = AttentionBlock(
                     channel_sizes[idx])
 
         # multi scale dilation block
@@ -126,7 +126,7 @@ class DFDNet(nn.Module):
         swap_feat = F.interpolate(dict_feat[select_idx:select_idx + 1],
                                   part_feat.size()[2:4])
         # attention
-        attn = self.attn_blocks[f'{part_name}_' + str(f_size)](
+        attn = self.attn_blocks['%s_%s' % (part_name, f_size)](
             swap_feat - part_feat)
         attn_feat = attn * swap_feat
         # update features
@@ -156,7 +156,7 @@ class DFDNet(nn.Module):
         updated_vgg_features = []
         batch = 0  # only supports testing with batch size = 0
         for vgg_layer, f_size in zip(self.vgg_layers, self.feature_sizes):
-            dict_features = self.dict[f'{f_size}']
+            dict_features = self.dict[str(f_size)]
             vgg_feat = vgg_features[vgg_layer]
             updated_feat = vgg_feat.clone()
 

--- a/basicsr/models/archs/discriminator_arch.py
+++ b/basicsr/models/archs/discriminator_arch.py
@@ -54,8 +54,8 @@ class VGGStyleDiscriminator128(nn.Module):
 
     def forward(self, x):
         assert x.size(2) == 128 and x.size(3) == 128, (
-            f'Input spatial size must be 128x128, '
-            f'but received {x.size()}.')
+            'Input spatial size must be 128x128, '
+            'but received %s.' % x.size())
 
         feat = self.lrelu(self.conv0_0(x))
         feat = self.lrelu(self.bn0_1(

--- a/basicsr/models/archs/duf_arch.py
+++ b/basicsr/models/archs/duf_arch.py
@@ -188,10 +188,10 @@ class DynamicUpsamplingFilter(nn.Module):
         super(DynamicUpsamplingFilter, self).__init__()
         if not isinstance(filter_size, tuple):
             raise TypeError('The type of filter_size must be tuple, '
-                            f'but got type{filter_size}')
+                            'but got type%s' % filter_size)
         if len(filter_size) != 2:
             raise ValueError('The length of filter size must be 2, '
-                             f'but got {len(filter_size)}.')
+                             'but got %d.' % len(filter_size))
         # generate a local expansion filter, similar to im2col
         self.filter_size = filter_size
         filter_prod = np.prod(filter_size)
@@ -278,7 +278,7 @@ class DUF(nn.Module):
             num_grow_ch = 16
         else:
             raise ValueError(
-                f'Only supported (16, 28, 52) layers, but got {num_layer}.')
+                'Only supported (16, 28, 52) layers, but got %d.' % num_layer)
 
         self.dense_block1 = DenseBlocks(
             num_block=num_block,

--- a/basicsr/models/archs/edvr_arch.py
+++ b/basicsr/models/archs/edvr_arch.py
@@ -33,7 +33,7 @@ class PCDAlignment(nn.Module):
 
         # Pyramids
         for i in range(3, 0, -1):
-            level = f'l{i}'
+            level = 'l%d' % i
             self.offset_conv1[level] = nn.Conv2d(num_feat * 2, num_feat, 3, 1,
                                                  1)
             if i == 3:
@@ -86,7 +86,7 @@ class PCDAlignment(nn.Module):
         # Pyramids
         upsampled_offset, upsampled_feat = None, None
         for i in range(3, 0, -1):
-            level = f'l{i}'
+            level = 'l%d' % i
             offset = torch.cat([nbr_feat_l[i - 1], ref_feat_l[i - 1]], dim=1)
             offset = self.lrelu(self.offset_conv1[level](offset))
             if i == 3:

--- a/basicsr/models/archs/stylegan2_arch.py
+++ b/basicsr/models/archs/stylegan2_arch.py
@@ -71,7 +71,7 @@ class UpFirDnUpsample(nn.Module):
         return out
 
     def __repr__(self):
-        return (f'{self.__class__.__name__}(factor={self.factor})')
+        return '%s(factor=%d)' % (self.__class__.__name__, self.factor)
 
 
 class UpFirDnDownsample(nn.Module):
@@ -97,7 +97,7 @@ class UpFirDnDownsample(nn.Module):
         return out
 
     def __repr__(self):
-        return (f'{self.__class__.__name__}(factor={self.factor})')
+        return '%s(factor=%d)' % (self.__class__.__name__, self.factor)
 
 
 class UpFirDnSmooth(nn.Module):
@@ -139,8 +139,8 @@ class UpFirDnSmooth(nn.Module):
 
     def __repr__(self):
         return (
-            f'{self.__class__.__name__}(upsample_factor={self.upsample_factor}'
-            f', downsample_factor={self.downsample_factor})')
+            '%s(upsample_factor=%s' % (self.__class__.__name__, self.upsample_factor) +
+            ', downsample_factor=%s)' % self.downsample_factor)
 
 
 class EqualLinear(nn.Module):
@@ -171,7 +171,7 @@ class EqualLinear(nn.Module):
         self.activation = activation
         if self.activation not in ['fused_lrelu', None]:
             raise ValueError(
-                f'Wrong activation value in EqualLinear: {activation}'
+                'Wrong activation value in EqualLinear: %s' % activation +
                 "Supported ones are: ['fused_lrelu', None].")
         self.scale = (1 / math.sqrt(in_channels)) * lr_mul
 
@@ -197,8 +197,8 @@ class EqualLinear(nn.Module):
 
     def __repr__(self):
         return (
-            f'{self.__class__.__name__}(in_channels={self.in_channels}, '
-            f'out_channels={self.out_channels}, bias={self.bias is not None})')
+            '%s(in_channels=%d, ' % (self.__class__.__name__, self.in_channels) +
+            'out_channels=%d, bias=%s)' % (self.out_channels, self.bias is not None))
 
 
 class ModulatedConv2d(nn.Module):
@@ -254,7 +254,7 @@ class ModulatedConv2d(nn.Module):
             pass
         else:
             raise ValueError(
-                f'Wrong sample mode {self.sample_mode}, '
+                'Wrong sample mode %s, ' % self.sample_mode +
                 "supported ones are ['upsample', 'downsample', None].")
 
         self.scale = 1 / math.sqrt(in_channels * kernel_size**2)
@@ -320,10 +320,10 @@ class ModulatedConv2d(nn.Module):
 
     def __repr__(self):
         return (
-            f'{self.__class__.__name__}(in_channels={self.in_channels}, '
-            f'out_channels={self.out_channels}, '
-            f'kernel_size={self.kernel_size}, '
-            f'demodulate={self.demodulate}, sample_mode={self.sample_mode})')
+            '%s(in_channels=%d, ' % (self.__class__.__name__, self.in_channels) +
+            'out_channels=%d, ' % self.out_channels +
+            'kernel_size=%d, ' % self.kernel_size +
+            'demodulate=%s, sample_mode=%s)' % (self.demodulate, self.sample_mode))
 
 
 class StyleConv(nn.Module):
@@ -521,11 +521,10 @@ class StyleGAN2Generator(nn.Module):
         for layer_idx in range(self.num_layers):
             resolution = 2**((layer_idx + 5) // 2)
             shape = [1, 1, resolution, resolution]
-            self.noises.register_buffer(f'noise{layer_idx}',
-                                        torch.randn(*shape))
+            self.noises.register_buffer('noise%d' % layer_idx, torch.randn(*shape))
         # style convs and to_rgbs
         for i in range(3, self.log_size + 1):
-            out_channels = channels[f'{2**i}']
+            out_channels = channels[str(2 ** i)]
             self.style_convs.append(
                 StyleConv(
                     in_channels,
@@ -609,7 +608,7 @@ class StyleGAN2Generator(nn.Module):
                 noise = [None] * self.num_layers  # for each style conv layer
             else:  # use the stored noise
                 noise = [
-                    getattr(self.noises, f'noise{i}')
+                    getattr(self.noises, 'noise%d' % i)
                     for i in range(self.num_layers)
                 ]
         # style truncation
@@ -725,11 +724,11 @@ class EqualConv2d(nn.Module):
         return out
 
     def __repr__(self):
-        return (f'{self.__class__.__name__}(in_channels={self.in_channels}, '
-                f'out_channels={self.out_channels}, '
-                f'kernel_size={self.kernel_size},'
-                f' stride={self.stride}, padding={self.padding}, '
-                f'bias={self.bias is not None})')
+        return ('%s(in_channels=%d, ' % (self.__class__.__name__, self.in_channels) +
+                'out_channels=%d, ' % self.out_channels +
+                'kernel_size=%d, ' % self.kernel_size +
+                'stride=%s, padding=%s, ' % (self.stride, self.padding) +
+                'bias=%s)' % self.bias is not None)
 
 
 class ConvLayer(nn.Sequential):
@@ -870,12 +869,12 @@ class StyleGAN2Discriminator(nn.Module):
         log_size = int(math.log(out_size, 2))
 
         conv_body = [
-            ConvLayer(3, channels[f'{out_size}'], 1, bias=True, activate=True)
+            ConvLayer(3, channels[str(out_size)], 1, bias=True, activate=True)
         ]
 
-        in_channels = channels[f'{out_size}']
+        in_channels = channels[str(out_size)]
         for i in range(log_size, 2, -1):
-            out_channels = channels[f'{2**(i - 1)}']
+            out_channels = channels[str(2**(i - 1))]
             conv_body.append(
                 ResBlock(in_channels, out_channels, resample_kernel))
             in_channels = out_channels

--- a/basicsr/models/base_model.py
+++ b/basicsr/models/base_model.py
@@ -87,7 +87,7 @@ class BaseModel():
                         optimizer, **train_opt['scheduler']))
         else:
             raise NotImplementedError(
-                f'Scheduler {scheduler_type} is not implemented yet.')
+                'Scheduler %s is not implemented yet.' % scheduler_type)
 
     def get_bare_model(self, net):
         """Get bare model, especially under wrapping with
@@ -105,17 +105,16 @@ class BaseModel():
             net (nn.Module)
         """
         if isinstance(net, (DataParallel, DistributedDataParallel)):
-            net_cls_str = (f'{net.__class__.__name__} - '
-                           f'{net.module.__class__.__name__}')
+            net_cls_str = ('%s - %s' % (net.__class__.__name__, net.module.__class__.__name__))
         else:
-            net_cls_str = f'{net.__class__.__name__}'
+            net_cls_str = net.__class__.__name__
 
         net = self.get_bare_model(net)
         net_str = str(net)
         net_params = sum(map(lambda x: x.numel(), net.parameters()))
 
         logger.info(
-            f'Network: {net_cls_str}, with parameters: {net_params:,d}')
+            'Network: {}, with parameters: {:,d}'.format(net_cls_str, net_params))
         logger.info(net_str)
 
     def _set_lr(self, lr_groups_l):
@@ -180,7 +179,7 @@ class BaseModel():
         """
         if current_iter == -1:
             current_iter = 'latest'
-        save_filename = f'{net_label}_{current_iter}.pth'
+        save_filename = '%s_%d.pth' % (net_label, current_iter)
         save_path = os.path.join(self.opt['path']['models'], save_filename)
 
         net = net if isinstance(net, list) else [net]
@@ -220,10 +219,10 @@ class BaseModel():
         if crt_net_keys != load_net_keys:
             logger.warning('Current net - loaded net:')
             for v in sorted(list(crt_net_keys - load_net_keys)):
-                logger.warning(f'  {v}')
+                logger.warning('  %s' % v)
             logger.warning('Loaded net - current net:')
             for v in sorted(list(load_net_keys - crt_net_keys)):
-                logger.warning(f'  {v}')
+                logger.warning('  %s' % v)
 
         # check the size for the same keys
         if not strict:
@@ -231,8 +230,8 @@ class BaseModel():
             for k in common_keys:
                 if crt_net[k].size() != load_net[k].size():
                     logger.warning(
-                        f'Size different, ignore [{k}]: crt_net: '
-                        f'{crt_net[k].shape}; load_net: {load_net[k].shape}')
+                        'Size different, ignore [%s]: crt_net: ' % k +
+                        '%d; load_net: %s' % (crt_net[k].shape, load_net[k].shape))
                     load_net[k + '.ignore'] = load_net.pop(k)
 
     def load_network(self, net, load_path, strict=True, param_key='params'):
@@ -248,7 +247,7 @@ class BaseModel():
         """
         net = self.get_bare_model(net)
         logger.info(
-            f'Loading {net.__class__.__name__} model from {load_path}.')
+            'Loading %s model from %s.' % (net.__class__.__name__, load_path))
         load_net = torch.load(
             load_path, map_location=lambda storage, loc: storage)
         if param_key is not None:
@@ -281,7 +280,7 @@ class BaseModel():
                 state['optimizers'].append(o.state_dict())
             for s in self.schedulers:
                 state['schedulers'].append(s.state_dict())
-            save_filename = f'{current_iter}.state'
+            save_filename = '%d.state' % current_iter
             save_path = os.path.join(self.opt['path']['training_states'],
                                      save_filename)
             torch.save(state, save_path)

--- a/basicsr/models/edvr_model.py
+++ b/basicsr/models/edvr_model.py
@@ -21,7 +21,7 @@ class EDVRModel(VideoBaseModel):
     def setup_optimizers(self):
         train_opt = self.opt['train']
         dcn_lr_mul = train_opt.get('dcn_lr_mul', 1)
-        logger.info(f'Multiple the learning rate for dcn with {dcn_lr_mul}.')
+        logger.info('Multiple the learning rate for dcn with %d.' % dcn_lr_mul)
         if dcn_lr_mul == 1:
             optim_params = self.net_g.parameters()
         else:  # separate dcn params and normal params for differnet lr
@@ -49,14 +49,14 @@ class EDVRModel(VideoBaseModel):
                                                 **train_opt['optim_g'])
         else:
             raise NotImplementedError(
-                f'optimizer {optim_type} is not supperted yet.')
+                'optimizer %s is not supperted yet.' % optim_type)
         self.optimizers.append(self.optimizer_g)
 
     def optimize_parameters(self, current_iter):
         if self.train_tsa_iter:
             if current_iter == 1:
                 logger.info(
-                    f'Only train TSA module for {self.train_tsa_iter} iters.')
+                    'Only train TSA module for %d iters.' % self.train_tsa_iter)
                 for name, param in self.net_g.named_parameters():
                     if 'fusion' not in name:
                         param.requires_grad = False

--- a/basicsr/models/losses/losses.py
+++ b/basicsr/models/losses/losses.py
@@ -37,8 +37,8 @@ class L1Loss(nn.Module):
     def __init__(self, loss_weight=1.0, reduction='mean'):
         super(L1Loss, self).__init__()
         if reduction not in ['none', 'mean', 'sum']:
-            raise ValueError(f'Unsupported reduction mode: {reduction}. '
-                             f'Supported ones are: {_reduction_modes}')
+            raise ValueError('Unsupported reduction mode: %s. ' % reduction +
+                             'Supported ones are: %s' % _reduction_modes)
 
         self.loss_weight = loss_weight
         self.reduction = reduction
@@ -67,8 +67,8 @@ class MSELoss(nn.Module):
     def __init__(self, loss_weight=1.0, reduction='mean'):
         super(MSELoss, self).__init__()
         if reduction not in ['none', 'mean', 'sum']:
-            raise ValueError(f'Unsupported reduction mode: {reduction}. '
-                             f'Supported ones are: {_reduction_modes}')
+            raise ValueError('Unsupported reduction mode: %s. ' % reduction +
+                             'Supported ones are: %s' % _reduction_modes)
 
         self.loss_weight = loss_weight
         self.reduction = reduction
@@ -103,8 +103,8 @@ class CharbonnierLoss(nn.Module):
     def __init__(self, loss_weight=1.0, reduction='mean', eps=1e-12):
         super(CharbonnierLoss, self).__init__()
         if reduction not in ['none', 'mean', 'sum']:
-            raise ValueError(f'Unsupported reduction mode: {reduction}. '
-                             f'Supported ones are: {_reduction_modes}')
+            raise ValueError('Unsupported reduction mode: %s. ' % reduction +
+                             'Supported ones are: %s' % _reduction_modes)
 
         self.loss_weight = loss_weight
         self.reduction = reduction
@@ -193,7 +193,7 @@ class PerceptualLoss(nn.Module):
             self.criterion = None
         else:
             raise NotImplementedError(
-                f'{criterion} criterion has not been supported.')
+                '%s criterion has not been supported.' % criterion)
 
     def forward(self, x, gt):
         """Forward function.
@@ -294,7 +294,7 @@ class GANLoss(nn.Module):
             self.loss = nn.ReLU()
         else:
             raise NotImplementedError(
-                f'GAN type {self.gan_type} is not implemented.')
+                'GAN type %s is not implemented.' % self.gan_type)
 
     def _wgan_loss(self, input, target):
         """wgan loss.

--- a/basicsr/models/ops/dcn/deform_conv.py
+++ b/basicsr/models/ops/dcn/deform_conv.py
@@ -23,7 +23,7 @@ class DeformConvFunction(Function):
                 deformable_groups=1,
                 im2col_step=64):
         if input is not None and input.dim() != 4:
-            raise ValueError(f'Expected 4D tensor as input, got {input.dim()}'
+            raise ValueError('Expected 4D tensor as input, got %d' % input.dim() +
                              'D tensor instead.')
         ctx.stride = _pair(stride)
         ctx.padding = _pair(padding)
@@ -104,7 +104,7 @@ class DeformConvFunction(Function):
             output_size += ((in_size + (2 * pad) - kernel) // stride_ + 1, )
         if not all(map(lambda s: s > 0, output_size)):
             raise ValueError('convolution input is too small (output would be '
-                             f'{"x".join(map(str, output_size))})')
+                             '%s)' % "x".join(map(str, output_size)))
         return output_size
 
 
@@ -201,10 +201,9 @@ class DeformConv(nn.Module):
 
         assert not bias
         assert in_channels % groups == 0, \
-            f'in_channels {in_channels} is not divisible by groups {groups}'
+            'in_channels %d is not divisible by groups %d' % (in_channels, groups)
         assert out_channels % groups == 0, \
-            f'out_channels {out_channels} is not divisible ' \
-            f'by groups {groups}'
+            'out_channels %d is not divisible by groups %d' % (out_channels, groups)
 
         self.in_channels = in_channels
         self.out_channels = out_channels

--- a/basicsr/models/sr_model.py
+++ b/basicsr/models/sr_model.py
@@ -69,7 +69,7 @@ class SRModel(BaseModel):
                 optim_params.append(v)
             else:
                 logger = get_root_logger()
-                logger.warning(f'Params {k} will not be optimized.')
+                logger.warning('Params %s will not be optimized.' % k)
 
         optim_type = train_opt['optim_g'].pop('type')
         if optim_type == 'Adam':
@@ -77,7 +77,7 @@ class SRModel(BaseModel):
                                                 **train_opt['optim_g'])
         else:
             raise NotImplementedError(
-                f'optimizer {optim_type} is not supperted yet.')
+                'optimizer %s is not supperted yet.' % optim_type)
         self.optimizers.append(self.optimizer_g)
 
     def feed_data(self, data):
@@ -153,16 +153,16 @@ class SRModel(BaseModel):
                 if self.opt['is_train']:
                     save_img_path = osp.join(self.opt['path']['visualization'],
                                              img_name,
-                                             f'{img_name}_{current_iter}.png')
+                                             '%s_%d.png' % (img_name, current_iter))
                 else:
                     if self.opt['val']['suffix']:
                         save_img_path = osp.join(
                             self.opt['path']['visualization'], dataset_name,
-                            f'{img_name}_{self.opt["val"]["suffix"]}.png')
+                            '%s_%s.png' % (img_name, self.opt["val"]["suffix"]))
                     else:
                         save_img_path = osp.join(
                             self.opt['path']['visualization'], dataset_name,
-                            f'{img_name}_{self.opt["name"]}.png')
+                            '%s_%s.png' % (img_name, self.opt["name"]))
                 imwrite(sr_img, save_img_path)
 
             if with_metrics:
@@ -173,7 +173,7 @@ class SRModel(BaseModel):
                     self.metric_results[name] += getattr(
                         metric_module, metric_type)(sr_img, gt_img, **opt_)
             pbar.update(1)
-            pbar.set_description(f'Test {img_name}')
+            pbar.set_description('Test %s' % img_name)
         pbar.close()
 
         if with_metrics:
@@ -185,14 +185,14 @@ class SRModel(BaseModel):
 
     def _log_validation_metric_values(self, current_iter, dataset_name,
                                       tb_logger):
-        log_str = f'Validation {dataset_name}\n'
+        log_str = 'Validation %s\n' % dataset_name
         for metric, value in self.metric_results.items():
-            log_str += f'\t # {metric}: {value:.4f}\n'
+            log_str += '\t # {}: {:.4f}\n'.format(metric, value)
         logger = get_root_logger()
         logger.info(log_str)
         if tb_logger:
             for metric, value in self.metric_results.items():
-                tb_logger.add_scalar(f'metrics/{metric}', value, current_iter)
+                tb_logger.add_scalar('metrics/%s' % metric, value, current_iter)
 
     def get_current_visuals(self):
         out_dict = OrderedDict()

--- a/basicsr/models/srgan_model.py
+++ b/basicsr/models/srgan_model.py
@@ -67,7 +67,7 @@ class SRGANModel(SRModel):
                                                 **train_opt['optim_g'])
         else:
             raise NotImplementedError(
-                f'optimizer {optim_type} is not supperted yet.')
+                'optimizer %s is not supperted yet.' % optim_type)
         self.optimizers.append(self.optimizer_g)
         # optimizer d
         optim_type = train_opt['optim_d'].pop('type')
@@ -76,7 +76,7 @@ class SRGANModel(SRModel):
                                                 **train_opt['optim_d'])
         else:
             raise NotImplementedError(
-                f'optimizer {optim_type} is not supperted yet.')
+                'optimizer %s is not supperted yet.' % optim_type)
         self.optimizers.append(self.optimizer_d)
 
     def optimize_parameters(self, current_iter):

--- a/basicsr/models/stylegan2_model.py
+++ b/basicsr/models/stylegan2_model.py
@@ -141,7 +141,7 @@ class StyleGAN2Model(BaseModel):
                 betas=(0**net_g_reg_ratio, 0.99**net_g_reg_ratio))
         else:
             raise NotImplementedError(
-                f'optimizer {optim_type} is not supperted yet.')
+                'optimizer %s is not supperted yet.' % optim_type)
         self.optimizers.append(self.optimizer_g)
 
         # optimizer d
@@ -181,7 +181,7 @@ class StyleGAN2Model(BaseModel):
                 betas=(0**net_d_reg_ratio, 0.99**net_d_reg_ratio))
         else:
             raise NotImplementedError(
-                f'optimizer {optim_type} is not supperted yet.')
+                'optimizer %s is not supperted yet.' % optim_type)
         self.optimizers.append(self.optimizer_d)
 
     def model_ema(self, decay=0.999):
@@ -309,10 +309,10 @@ class StyleGAN2Model(BaseModel):
         result = tensor2img(self.output, min_max=(-1, 1))
         if self.opt['is_train']:
             save_img_path = osp.join(self.opt['path']['visualization'],
-                                     'train', f'train_{current_iter}.png')
+                                     'train', 'train_%d.png' % current_iter)
         else:
             save_img_path = osp.join(self.opt['path']['visualization'], 'test',
-                                     f'test_{self.opt["name"]}.png')
+                                     'test_%s.png' % self.opt["name"])
         imwrite(result, save_img_path)
         # add sample images to tb_logger
         result = (result / 255.).astype(np.float32)

--- a/basicsr/models/video_base_model.py
+++ b/basicsr/models/video_base_model.py
@@ -69,8 +69,7 @@ class VideoBaseModel(SRModel):
                 else:
                     if 'vimeo' in dataset_name.lower():  # vimeo90k dataset
                         split_result = lq_path.split('/')
-                        img_name = (f'{split_result[-3]}_{split_result[-2]}_'
-                                    f'{split_result[-1].split(".")[0]}')
+                        img_name = '%s_%s_%s' % (split_result[-3], split_result[-2], split_result[-1].split(".")[0])
                     else:  # other datasets, e.g., REDS, Vid4
                         img_name = osp.splitext(osp.basename(lq_path))[0]
 
@@ -78,11 +77,11 @@ class VideoBaseModel(SRModel):
                         save_img_path = osp.join(
                             self.opt['path']['visualization'], dataset_name,
                             folder,
-                            f'{img_name}_{self.opt["val"]["suffix"]}.png')
+                            '%s_%s.png' % (img_name, self.opt["val"]["suffix"]))
                     else:
                         save_img_path = osp.join(
                             self.opt['path']['visualization'], dataset_name,
-                            folder, f'{img_name}_{self.opt["name"]}.png')
+                            folder, '%s_%s.png' % (img_name, self.opt["name"]))
                 imwrite(result_img, save_img_path)
 
             if with_metrics:
@@ -100,8 +99,8 @@ class VideoBaseModel(SRModel):
                 for _ in range(world_size):
                     pbar.update(1)
                     pbar.set_description(
-                        f'Test {folder}:'
-                        f'{int(frame_idx) + world_size}/{max_idx}')
+                        'Test %s:' % folder +
+                        '%d/%s' % (int(frame_idx) + world_size, max_idx))
         if rank == 0:
             pbar.close()
 
@@ -152,12 +151,12 @@ class VideoBaseModel(SRModel):
         for metric in total_avg_results.keys():
             total_avg_results[metric] /= len(metric_results_avg)
 
-        log_str = f'Validation {dataset_name}\n'
+        log_str = 'Validation %s\n' % dataset_name
         for metric_idx, (metric,
                          value) in enumerate(total_avg_results.items()):
-            log_str += f'\t # {metric}: {value:.4f}'
+            log_str += '\t # {}: {:.4f}'.format(metric, value)
             for folder, tensor in metric_results_avg.items():
-                log_str += f'\t # {folder}: {tensor[metric_idx].item():.4f}'
+                log_str += '\t # {}: {:.4f}'.format(folder, tensor[metric_idx].item())
             log_str += '\n'
 
         logger = get_root_logger()
@@ -165,8 +164,8 @@ class VideoBaseModel(SRModel):
         if tb_logger:
             for metric_idx, (metric,
                              value) in enumerate(total_avg_results.items()):
-                tb_logger.add_scalar(f'metrics/{metric}', value, current_iter)
+                tb_logger.add_scalar('metrics/%s' % metric, value, current_iter)
                 for folder, tensor in metric_results_avg.items():
-                    tb_logger.add_scalar(f'metrics/{metric}/{folder}',
+                    tb_logger.add_scalar('metrics/%s/%s' % (metric, folder),
                                          tensor[metric_idx].item(),
                                          current_iter)

--- a/basicsr/test.py
+++ b/basicsr/test.py
@@ -20,7 +20,7 @@ def main():
     # mkdir and initialize loggers
     make_exp_dirs(opt)
     log_file = osp.join(opt['path']['log'],
-                        f"test_{opt['name']}_{get_time_str()}.log")
+                        "test_%s_%s.log" % (opt['name'], get_time_str()))
     logger = get_root_logger(
         logger_name='basicsr', log_level=logging.INFO, log_file=log_file)
     logger.info(get_env_info())
@@ -38,7 +38,7 @@ def main():
             sampler=None,
             seed=opt['manual_seed'])
         logger.info(
-            f"Number of test images in {dataset_opt['name']}: {len(test_set)}")
+            "Number of test images in %s: %d" % (dataset_opt['name'], len(test_set)))
         test_loaders.append(test_loader)
 
     # create model
@@ -46,7 +46,7 @@ def main():
 
     for test_loader in test_loaders:
         test_set_name = test_loader.dataset.opt['name']
-        logger.info(f'Testing {test_set_name}...')
+        logger.info('Testing %s...' % test_set_name)
         model.validation(
             test_loader,
             current_iter=opt['name'],

--- a/basicsr/train.py
+++ b/basicsr/train.py
@@ -57,7 +57,7 @@ def parse_options(is_train=True):
 
 def init_loggers(opt):
     log_file = osp.join(opt['path']['log'],
-                        f"train_{opt['name']}_{get_time_str()}.log")
+                        "train_%s_%s.log" % (opt['name'], get_time_str()))
     logger = get_root_logger(
         logger_name='basicsr', log_level=logging.INFO, log_file=log_file)
     logger.info(get_env_info())
@@ -100,12 +100,12 @@ def create_train_val_dataloader(opt, logger):
             total_epochs = math.ceil(total_iters / (num_iter_per_epoch))
             logger.info(
                 'Training statistics:'
-                f'\n\tNumber of train images: {len(train_set)}'
-                f'\n\tDataset enlarge ratio: {dataset_enlarge_ratio}'
-                f'\n\tBatch size per gpu: {dataset_opt["batch_size_per_gpu"]}'
-                f'\n\tWorld size (gpu number): {opt["world_size"]}'
-                f'\n\tRequire iter number per epoch: {num_iter_per_epoch}'
-                f'\n\tTotal epochs: {total_epochs}; iters: {total_iters}.')
+                '\n\tNumber of train images: %d' % len(train_set) +
+                '\n\tDataset enlarge ratio: %s' % dataset_enlarge_ratio +
+                '\n\tBatch size per gpu: %d' % dataset_opt["batch_size_per_gpu"] +
+                '\n\tWorld size (gpu number): %d' % opt["world_size"] +
+                '\n\tRequire iter number per epoch: %d' % num_iter_per_epoch +
+                '\n\tTotal epochs: %d; iters: %d.' % (total_epochs, total_iters))
 
         elif phase == 'val':
             val_set = create_dataset(dataset_opt)
@@ -117,10 +117,10 @@ def create_train_val_dataloader(opt, logger):
                 sampler=None,
                 seed=opt['manual_seed'])
             logger.info(
-                f'Number of val images/folders in {dataset_opt["name"]}: '
-                f'{len(val_set)}')
+                'Number of val images/folders in %s: %d' %
+                (dataset_opt["name"], len(val_set)))
         else:
-            raise ValueError(f'Dataset phase {phase} is not recognized.')
+            raise ValueError('Dataset phase %s is not recognized.' % phase)
 
     return train_loader, train_sampler, val_loader, total_epochs, total_iters
 
@@ -160,8 +160,8 @@ def main():
         check_resume(opt, resume_state['iter'])
         model = create_model(opt)
         model.resume_training(resume_state)  # handle optimizers and schedulers
-        logger.info(f"Resuming training from epoch: {resume_state['epoch']}, "
-                    f"iter: {resume_state['iter']}.")
+        logger.info("Resuming training from epoch: %d, " % resume_state['epoch'] +
+                    "iter: %d." % resume_state['iter'])
         start_epoch = resume_state['epoch']
         current_iter = resume_state['iter']
     else:
@@ -178,16 +178,16 @@ def main():
         prefetcher = CPUPrefetcher(train_loader)
     elif prefetch_mode == 'cuda':
         prefetcher = CUDAPrefetcher(train_loader, opt)
-        logger.info(f'Use {prefetch_mode} prefetch dataloader')
+        logger.info('Use %s prefetch dataloader' % prefetch_mode)
         if opt['datasets']['train'].get('pin_memory') is not True:
             raise ValueError('Please set pin_memory=True for CUDAPrefetcher.')
     else:
-        raise ValueError(f'Wrong prefetch_mode {prefetch_mode}.'
+        raise ValueError('Wrong prefetch_mode %s.' % prefetch_mode +
                          "Supported ones are: None, 'cuda', 'cpu'.")
 
     # training
     logger.info(
-        f'Start training from epoch: {start_epoch}, iter: {current_iter}')
+        'Start training from epoch: %d, iter: %d' % (start_epoch, current_iter))
     data_time, iter_time = time.time(), time.time()
     start_time = time.time()
 
@@ -237,7 +237,7 @@ def main():
 
     consumed_time = str(
         datetime.timedelta(seconds=int(time.time() - start_time)))
-    logger.info(f'End of training. Time consumed: {consumed_time}')
+    logger.info('End of training. Time consumed: %s' % consumed_time)
     logger.info('Save the latest model.')
     model.save(epoch=-1, current_iter=-1)  # -1 stands for the latest
     if opt.get('val') is not None:

--- a/basicsr/utils/dist_util.py
+++ b/basicsr/utils/dist_util.py
@@ -15,7 +15,7 @@ def init_dist(launcher, backend='nccl', **kwargs):
     elif launcher == 'slurm':
         _init_dist_slurm(backend, **kwargs)
     else:
-        raise ValueError(f'Invalid launcher type: {launcher}')
+        raise ValueError('Invalid launcher type: %s' % launcher)
 
 
 def _init_dist_pytorch(backend, **kwargs):
@@ -42,7 +42,7 @@ def _init_dist_slurm(backend, port=None):
     num_gpus = torch.cuda.device_count()
     torch.cuda.set_device(proc_id % num_gpus)
     addr = subprocess.getoutput(
-        f'scontrol show hostname {node_list} | head -n1')
+        'scontrol show hostname %s | head -n1' % node_list)
     # specify master port
     if port is not None:
         os.environ['MASTER_PORT'] = str(port)

--- a/basicsr/utils/download_util.py
+++ b/basicsr/utils/download_util.py
@@ -62,8 +62,8 @@ def save_response_content(response,
             downloaded_size += chunk_size
             if pbar is not None:
                 pbar.update(1)
-                pbar.set_description(f'Download {sizeof_fmt(downloaded_size)} '
-                                     f'/ {readable_file_size}')
+                pbar.set_description('Download %s ' % sizeof_fmt(downloaded_size) +
+                                     f'/ %s' % readable_file_size)
             if chunk:  # filter out keep-alive new chunks
                 f.write(chunk)
         if pbar is not None:

--- a/basicsr/utils/face_util.py
+++ b/basicsr/utils/face_util.py
@@ -103,7 +103,7 @@ class FaceRestorationHelper(object):
             # face detection
             det_face = self.face_detector(face, 1)  # TODO: can we remove it?
             if len(det_face) == 0:
-                print(f'Cannot find faces in cropped image with index {idx}.')
+                print('Cannot find faces in cropped image with index %d.' % idx)
                 self.all_landmarks_68.append(None)
             else:
                 if len(det_face) > 1:
@@ -149,9 +149,9 @@ class FaceRestorationHelper(object):
             if save_cropped_path is not None:
                 path, ext = os.path.splitext(save_cropped_path)
                 if self.save_png:
-                    save_path = f'{path}_{idx:02d}.png'
+                    save_path = '{}_{:02d}.png'.format(path, idx)
                 else:
-                    save_path = f'{path}_{idx:02d}{ext}'
+                    save_path = '{}_{:02d}{}'.format(path, idx, ext)
 
                 imwrite(
                     cv2.cvtColor(cropped_face, cv2.COLOR_RGB2BGR), save_path)
@@ -164,7 +164,7 @@ class FaceRestorationHelper(object):
             # save inverse affine matrices
             if save_inverse_affine_path is not None:
                 path, _ = os.path.splitext(save_inverse_affine_path)
-                save_path = f'{path}_{idx:02d}.pth'
+                save_path = '{}_{:02d}.pth'.format(path, idx)
                 torch.save(inverse_affine, save_path)
 
     def add_restored_face(self, face):

--- a/basicsr/utils/file_client.py
+++ b/basicsr/utils/file_client.py
@@ -114,7 +114,7 @@ class LmdbBackend(BaseStorageBackend):
             self.db_paths = [str(db_paths)]
         assert len(client_keys) == len(self.db_paths), (
             'client_keys and db_paths should have the same length, '
-            f'but received {len(client_keys)} and {len(self.db_paths)}.')
+            'but received %d and %d.' % (len(client_keys), len(self.db_paths)))
 
         self._client = {}
         for client, path in zip(client_keys, self.db_paths):
@@ -133,7 +133,7 @@ class LmdbBackend(BaseStorageBackend):
             client_key (str): Used for distinguishing differnet lmdb envs.
         """
         filepath = str(filepath)
-        assert client_key in self._client, (f'client_key {client_key} is not '
+        assert client_key in self._client, ('client_key %s is not ' % client_key +
                                             'in lmdb clients.')
         client = self._client[client_key]
         with client.begin(write=False) as txn:
@@ -166,8 +166,8 @@ class FileClient(object):
     def __init__(self, backend='disk', **kwargs):
         if backend not in self._backends:
             raise ValueError(
-                f'Backend {backend} is not supported. Currently supported ones'
-                f' are {list(self._backends.keys())}')
+                'Backend %s is not supported. Currently supported ones' % backend +
+                ' are %s' % list(self._backends.keys()))
         self.backend = backend
         self.client = self._backends[backend](**kwargs)
 

--- a/basicsr/utils/flow_util.py
+++ b/basicsr/utils/flow_util.py
@@ -21,8 +21,8 @@ def flowread(flow_path, quantize=False, concat_axis=0, *args, **kwargs):
         assert concat_axis in [0, 1]
         cat_flow = cv2.imread(flow_path, cv2.IMREAD_UNCHANGED)
         if cat_flow.ndim != 2:
-            raise IOError(f'{flow_path} is not a valid quantized flow file, '
-                          f'its dimension is {cat_flow.ndim}.')
+            raise IOError('%s is not a valid quantized flow file, ' % flow_path +
+                          'its dimension is %d.' % cat_flow.ndim)
         assert cat_flow.shape[concat_axis] % 2 == 0
         dx, dy = np.split(cat_flow, 2, axis=concat_axis)
         flow = dequantize_flow(dx, dy, *args, **kwargs)
@@ -31,10 +31,10 @@ def flowread(flow_path, quantize=False, concat_axis=0, *args, **kwargs):
             try:
                 header = f.read(4).decode('utf-8')
             except Exception:
-                raise IOError(f'Invalid flow file: {flow_path}')
+                raise IOError('Invalid flow file: %s' % flow_path)
             else:
                 if header != 'PIEH':
-                    raise IOError(f'Invalid flow file: {flow_path}, '
+                    raise IOError('Invalid flow file: %s, ' % flow_path +
                                   'header does not contain PIEH')
 
             w = np.fromfile(f, np.int32, 1).squeeze()
@@ -142,10 +142,10 @@ def quantize(arr, min_val, max_val, levels, dtype=np.int64):
     """
     if not (isinstance(levels, int) and levels > 1):
         raise ValueError(
-            f'levels must be a positive integer, but got {levels}')
+            'levels must be a positive integer, but got %s' % levels)
     if min_val >= max_val:
         raise ValueError(
-            f'min_val ({min_val}) must be smaller than max_val ({max_val})')
+            'min_val (%s) must be smaller than max_val (%s)' % (min_val, max_val))
 
     arr = np.clip(arr, min_val, max_val) - min_val
     quantized_arr = np.minimum(
@@ -169,10 +169,10 @@ def dequantize(arr, min_val, max_val, levels, dtype=np.float64):
     """
     if not (isinstance(levels, int) and levels > 1):
         raise ValueError(
-            f'levels must be a positive integer, but got {levels}')
+            'levels must be a positive integer, but got %s' % levels)
     if min_val >= max_val:
         raise ValueError(
-            f'min_val ({min_val}) must be smaller than max_val ({max_val})')
+            'min_val (%s) must be smaller than max_val (%s)' % (min_val, max_val))
 
     dequantized_arr = (arr + 0.5).astype(dtype) * (max_val -
                                                    min_val) / levels + min_val

--- a/basicsr/utils/img_util.py
+++ b/basicsr/utils/img_util.py
@@ -58,7 +58,7 @@ def tensor2img(tensor, rgb2bgr=True, out_type=np.uint8, min_max=(0, 1)):
             (isinstance(tensor, list)
              and all(torch.is_tensor(t) for t in tensor))):
         raise TypeError(
-            f'tensor or list of tensors expected, got {type(tensor)}')
+            'tensor or list of tensors expected, got %s' % type(tensor))
 
     if torch.is_tensor(tensor):
         tensor = [tensor]
@@ -87,7 +87,7 @@ def tensor2img(tensor, rgb2bgr=True, out_type=np.uint8, min_max=(0, 1)):
             img_np = _tensor.numpy()
         else:
             raise TypeError('Only support 4D, 3D or 2D tensor. '
-                            f'But received with dimension: {n_dim}')
+                            'But received with dimension: %d' % n_dim)
         if out_type == np.uint8:
             # Unlike MATLAB, numpy.unit8() WILL NOT round by default.
             img_np = (img_np * 255.0).round()

--- a/basicsr/utils/lmdb_util.py
+++ b/basicsr/utils/lmdb_util.py
@@ -60,27 +60,27 @@ def make_lmdb_from_imgs(data_path,
 
     assert len(img_path_list) == len(keys), (
         'img_path_list and keys should have the same length, '
-        f'but got {len(img_path_list)} and {len(keys)}')
-    print(f'Create lmdb for {data_path}, save to {lmdb_path}...')
-    print(f'Totoal images: {len(img_path_list)}')
+        'but got %d and %d' % (len(img_path_list), len(keys)))
+    print('Create lmdb for %s, save to %s...' % (data_path, lmdb_path))
+    print('Totoal images: %d' % len(img_path_list))
     if not lmdb_path.endswith('.lmdb'):
         raise ValueError("lmdb_path must end with '.lmdb'.")
     if osp.exists(lmdb_path):
-        print(f'Folder {lmdb_path} already exists. Exit.')
+        print('Folder %s already exists. Exit.' % lmdb_path)
         sys.exit(1)
 
     if multiprocessing_read:
         # read all the images to memory (multiprocessing)
         dataset = {}  # use dict to keep the order for multiprocessing
         shapes = {}
-        print(f'Read images with multiprocessing, #thread: {n_thread} ...')
+        print('Read images with multiprocessing, #thread: %s ...' % n_thread)
         pbar = tqdm(total=len(img_path_list), unit='image')
 
         def callback(arg):
             """get the image data and update pbar."""
             key, dataset[key], shapes[key] = arg
             pbar.update(1)
-            pbar.set_description(f'Read {key}')
+            pbar.set_description('Read %s' % key)
 
         pool = Pool(n_thread)
         for path, key in zip(img_path_list, keys):
@@ -91,7 +91,7 @@ def make_lmdb_from_imgs(data_path,
         pool.close()
         pool.join()
         pbar.close()
-        print(f'Finish reading {len(img_path_list)} images.')
+        print('Finish reading %d images.' % len(img_path_list))
 
     # create lmdb environment
     if map_size is None:
@@ -113,7 +113,7 @@ def make_lmdb_from_imgs(data_path,
     txt_file = open(osp.join(lmdb_path, 'meta_info.txt'), 'w')
     for idx, (path, key) in enumerate(zip(img_path_list, keys)):
         pbar.update(1)
-        pbar.set_description(f'Write {key}')
+        pbar.set_description('Write %s' % key)
         key_byte = key.encode('ascii')
         if multiprocessing_read:
             img_byte = dataset[key]
@@ -125,7 +125,7 @@ def make_lmdb_from_imgs(data_path,
 
         txn.put(key_byte, img_byte)
         # write meta information
-        txt_file.write(f'{key}.png ({h},{w},{c}) {compress_level}\n')
+        txt_file.write('%s.png (%d,%d,%d) %s\n' % (key, h, w, c, compress_level))
         if idx % batch == 0:
             txn.commit()
             txn = env.begin(write=True)
@@ -180,7 +180,7 @@ class LmdbMaker():
         if not lmdb_path.endswith('.lmdb'):
             raise ValueError("lmdb_path must end with '.lmdb'.")
         if osp.exists(lmdb_path):
-            print(f'Folder {lmdb_path} already exists. Exit.')
+            print('Folder %s already exists. Exit.' % lmdb_path)
             sys.exit(1)
 
         self.lmdb_path = lmdb_path
@@ -197,7 +197,7 @@ class LmdbMaker():
         self.txn.put(key_byte, img_byte)
         # write meta information
         h, w, c = img_shape
-        self.txt_file.write(f'{key}.png ({h},{w},{c}) {self.compress_level}\n')
+        self.txt_file.write('%s.png (%d,%d,%d) %s\n' % (key, h, w, c, self.compress_level))
         if self.counter % self.batch == 0:
             self.txn.commit()
             self.txn = self.env.begin(write=True)

--- a/basicsr/utils/logger.py
+++ b/basicsr/utils/logger.py
@@ -46,10 +46,10 @@ class MessageLogger():
         current_iter = log_vars.pop('iter')
         lrs = log_vars.pop('lrs')
 
-        message = (f'[{self.exp_name[:5]}..][epoch:{epoch:3d}, '
-                   f'iter:{current_iter:8,d}, lr:(')
+        message = ('[{}..][epoch:{:3d}, iter:{:8,d}, lr:('.format(
+            self.exp_name[:5], epoch, current_iter))
         for v in lrs:
-            message += f'{v:.3e},'
+            message += '{:.3e},'.format(v)
         message += ')] '
 
         # time and estimated time
@@ -61,16 +61,16 @@ class MessageLogger():
             time_sec_avg = total_time / (current_iter - self.start_iter + 1)
             eta_sec = time_sec_avg * (self.max_iters - current_iter - 1)
             eta_str = str(datetime.timedelta(seconds=int(eta_sec)))
-            message += f'[eta: {eta_str}, '
-            message += f'time (data): {iter_time:.3f} ({data_time:.3f})] '
+            message += '[eta: %s, ' % eta_str
+            message += 'time (data): {:.3f} ({:.3f})] '.format(iter_time, data_time)
 
         # other items, especially losses
         for k, v in log_vars.items():
-            message += f'{k}: {v:.4e} '
+            message += '{}: {:.4e} '.format(k, v)
             # tensorboard logger
             if self.use_tb_logger and 'debug' not in self.exp_name:
                 if k.startswith('l_'):
-                    self.tb_logger.add_scalar(f'losses/{k}', v, current_iter)
+                    self.tb_logger.add_scalar('losses/%s' % k, v, current_iter)
                 else:
                     self.tb_logger.add_scalar(k, v, current_iter)
         self.logger.info(message)
@@ -94,7 +94,7 @@ def init_wandb_logger(opt):
     if resume_id:
         wandb_id = resume_id
         resume = 'allow'
-        logger.warning(f'Resume wandb logger with id={wandb_id}.')
+        logger.warning('Resume wandb logger with id=%s.' % wandb_id)
     else:
         wandb_id = wandb.util.generate_id()
         resume = 'never'
@@ -107,7 +107,7 @@ def init_wandb_logger(opt):
         project=project,
         sync_tensorboard=True)
 
-    logger.info(f'Use wandb logger with id={wandb_id}; project={project}.')
+    logger.info('Use wandb logger with id=%s; project=%s.' % (wandb_id, project))
 
 
 def get_root_logger(logger_name='basicsr',
@@ -171,7 +171,7 @@ def get_env_info():
   \____/ \____/ \____/ \____/  /_____/\____/ \___//_/|_|  (_)
     """
     msg += ('\nVersion Information: '
-            f'\n\tBasicSR: {__version__}'
-            f'\n\tPyTorch: {torch.__version__}'
-            f'\n\tTorchVision: {torchvision.__version__}')
+            '\n\tBasicSR: %s' % __version__ +
+            '\n\tPyTorch: %s' % torch.__version__ +
+            '\n\tTorchVision: %s' % torchvision.__version__)
     return msg

--- a/basicsr/utils/matlab_functions.py
+++ b/basicsr/utils/matlab_functions.py
@@ -326,7 +326,7 @@ def _convert_input_type_range(img):
         img /= 255.
     else:
         raise TypeError('The img type should be np.float32 or np.uint8, '
-                        f'but got {img_type}')
+                        'but got %s' % img_type)
     return img
 
 
@@ -353,7 +353,7 @@ def _convert_output_type_range(img, dst_type):
     """
     if dst_type not in (np.uint8, np.float32):
         raise TypeError('The dst_type should be np.float32 or np.uint8, '
-                        f'but got {dst_type}')
+                        'but got %s' % dst_type)
     if dst_type == np.uint8:
         img = img.round()
     else:

--- a/basicsr/utils/misc.py
+++ b/basicsr/utils/misc.py
@@ -30,7 +30,7 @@ def mkdir_and_rename(path):
     """
     if osp.exists(path):
         new_name = path + '_archived_' + get_time_str()
-        print(f'Path already exists. Rename it to {new_name}', flush=True)
+        print('Path already exists. Rename it to %s' % new_name, flush=True)
         os.rename(path, new_name)
     os.makedirs(path, exist_ok=True)
 
@@ -106,20 +106,20 @@ def check_resume(opt, resume_iter):
         networks = [key for key in opt.keys() if key.startswith('network_')]
         flag_pretrain = False
         for network in networks:
-            if opt['path'].get(f'pretrain_{network}') is not None:
+            if opt['path'].get('pretrain_%s' % network) is not None:
                 flag_pretrain = True
         if flag_pretrain:
             logger.warning(
                 'pretrain_network path will be ignored during resuming.')
         # set pretrained model paths
         for network in networks:
-            name = f'pretrain_{network}'
+            name = 'pretrain_%s' % network
             basename = network.replace('network_', '')
             if opt['path'].get('ignore_resume_networks') is None or (
                     basename not in opt['path']['ignore_resume_networks']):
                 opt['path'][name] = osp.join(
-                    opt['path']['models'], f'net_{basename}_{resume_iter}.pth')
-                logger.info(f"Set {name} to {opt['path'][name]}")
+                    opt['path']['models'], 'net_%s_%s.pth' % (basename, resume_iter))
+                logger.info('Set %s to %s' % (name, opt['path'][name]))
 
 
 def sizeof_fmt(size, suffix='B'):
@@ -134,6 +134,6 @@ def sizeof_fmt(size, suffix='B'):
     """
     for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
         if abs(size) < 1024.0:
-            return f'{size:3.1f} {unit}{suffix}'
+            return '{:3.1f} {}{}'.format(size, unit, suffix)
         size /= 1024.0
-    return f'{size:3.1f} Y{suffix}'
+    return '{:3.1f} Y{}'.format(size, suffix)

--- a/inference/inference_dfdnet.py
+++ b/inference/inference_dfdnet.py
@@ -110,7 +110,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     if args.test_path.endswith('/'):  # solve when path ends with /
         args.test_path = args.test_path[:-1]
-    result_root = f'results/DFDNet/{os.path.basename(args.test_path)}'
+    result_root = 'results/DFDNet/%s' % os.path.basename(args.test_path)
 
     # set up the DFDNet
     net = DFDNet(64, dict_path=args.dict_path).to(device)
@@ -131,7 +131,7 @@ if __name__ == '__main__':
     for img_path in sorted(
             glob.glob(os.path.join(args.test_path, '*.[jp][pn]g'))):
         img_name = os.path.basename(img_path)
-        print(f'Processing {img_name} image ...')
+        print('Processing %s image ...' % img_name)
         save_crop_path = os.path.join(save_crop_root, img_name)
         if args.save_inverse_affine:
             save_inverse_affine_path = os.path.join(save_inverse_affine_root,
@@ -148,20 +148,20 @@ if __name__ == '__main__':
             only_keep_largest=args.only_keep_largest)
         # get 5 face landmarks for each face
         num_landmarks = face_helper.get_face_landmarks_5()
-        print(f'\tDetect {num_det_faces} faces, {num_landmarks} landmarks.')
+        print('\tDetect %d faces, %d landmarks.' % (num_det_faces, num_landmarks))
         # warp and crop each face
         face_helper.warp_crop_faces(save_crop_path, save_inverse_affine_path)
 
         if args.official_adaption:
             path, ext = os.path.splitext(save_crop_path)
-            pathes = sorted(glob.glob(f'{path}_[0-9]*.png'))
+            pathes = sorted(glob.glob('%s_[0-9]*.png' % path))
             cropped_faces = [io.imread(path) for path in pathes]
         else:
             cropped_faces = face_helper.cropped_faces
 
         # get 68 landmarks for each cropped face
         num_landmarks = face_helper.get_face_landmarks_68()
-        print(f'\tDetect {num_landmarks} faces for 68 landmarks.')
+        print('\tDetect %d faces for 68 landmarks.' % num_landmarks)
 
         face_helper.free_dlib_gpu_memory()
 
@@ -171,7 +171,7 @@ if __name__ == '__main__':
         for idx, (cropped_face, landmarks) in enumerate(
                 zip(cropped_faces, face_helper.all_landmarks_68)):
             if landmarks is None:
-                print(f'Landmarks is None, skip cropped faces with idx {idx}.')
+                print('Landmarks is None, skip cropped faces with idx %d.' % idx)
                 # just copy the cropped faces to the restored faces
                 restored_face = cropped_face
             else:
@@ -190,12 +190,12 @@ if __name__ == '__main__':
                     del output
                     torch.cuda.empty_cache()
                 except Exception as e:
-                    print(f'DFDNet inference fail: {e}')
+                    print('DFDNet inference fail: %s' % e)
                     restored_face = tensor2img(cropped_face, min_max=(-1, 1))
 
             path = os.path.splitext(os.path.join(save_restore_root,
                                                  img_name))[0]
-            save_path = f'{path}_{idx:02d}.png'
+            save_path = '{}_{:02d}.png'.format(path, idx)
             imwrite(restored_face, save_path)
             face_helper.add_restored_face(restored_face)
 
@@ -207,4 +207,4 @@ if __name__ == '__main__':
         # clean all the intermediate results to process the next image
         face_helper.clean_all()
 
-    print(f'\nAll results are saved in {result_root}')
+    print('\nAll results are saved in %s' % result_root)

--- a/inference/inference_esrgan.py
+++ b/inference/inference_esrgan.py
@@ -48,7 +48,7 @@ def main():
         output = output.data.squeeze().float().cpu().clamp_(0, 1).numpy()
         output = np.transpose(output[[2, 1, 0], :, :], (1, 2, 0))
         output = (output * 255.0).round().astype(np.uint8)
-        cv2.imwrite(f'results/ESRGAN/{imgname}_ESRGAN.png', output)
+        cv2.imwrite('results/ESRGAN/%s_ESRGAN.png' % imgname, output)
 
 
 if __name__ == '__main__':

--- a/inference/inference_ridnet.py
+++ b/inference/inference_ridnet.py
@@ -23,8 +23,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
     if args.test_path.endswith('/'):  # solve when path ends with /
         args.test_path = args.test_path[:-1]
-    test_root = os.path.join(args.test_path, f'X{args.noise_g}')
-    result_root = f'results/RIDNet/{os.path.basename(args.test_path)}'
+    test_root = os.path.join(args.test_path, 'X%s' % args.noise_g)
+    result_root = 'results/RIDNet/%s' % os.path.basename(args.test_path)
     os.makedirs(result_root, exist_ok=True)
 
     # set up the RIDNet
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     for idx, img_path in enumerate(img_list):
         img_name = os.path.basename(img_path).split('.')[0]
         pbar.update(1)
-        pbar.set_description(f'{idx}: {img_name}')
+        pbar.set_description('%d: %s' % (idx, img_name))
         # read image
         img = cv2.imread(img_path, cv2.IMREAD_COLOR)
         img = img2tensor(
@@ -52,6 +52,6 @@ if __name__ == '__main__':
         output = tensor2img(
             output, rgb2bgr=True, out_type=np.uint8, min_max=(0, 255))
         save_img_path = os.path.join(
-            result_root, f'{img_name}_x'
-            f'{args.noise_g}_RIDNet.png')
+            result_root, '%s_x' % img_name,
+            '%s_RIDNet.png' % args.noise_g)
         cv2.imwrite(save_img_path, output)

--- a/inference/inference_stylegan2.py
+++ b/inference/inference_stylegan2.py
@@ -22,7 +22,7 @@ def generate(args, g_ema, device, mean_latent, randomize_noise):
 
             utils.save_image(
                 sample,
-                f'samples/{str(i).zfill(6)}.png',
+                'samples/%s.png' % str(i).zfill(6),
                 nrow=int(math.sqrt(args.sample)),
                 normalize=True,
                 range=(-1, 1),

--- a/scripts/data_preparation/create_lmdb.py
+++ b/scripts/data_preparation/create_lmdb.py
@@ -149,8 +149,8 @@ def prepare_keys_vimeo90k(folder_path, train_list_path, mode):
     for line in train_list:
         folder, sub_folder = line.split('/')
         img_path_list.extend(
-            [osp.join(folder, sub_folder, f'im{j + 1}.png') for j in range(7)])
-        keys.extend([f'{folder}/{sub_folder}/im{j + 1}' for j in range(7)])
+            [osp.join(folder, sub_folder, 'im%d.png' % (j + 1)) for j in range(7)])
+        keys.extend(['%s/%s/im%d' % (folder, sub_folder, j + 1) for j in range(7)])
 
     if mode == 'gt':
         print('Only keep the 4th frame for the gt mode.')

--- a/scripts/data_preparation/download_datasets.py
+++ b/scripts/data_preparation/download_datasets.py
@@ -14,22 +14,22 @@ def download_dataset(dataset, file_ids):
         save_path = osp.abspath(osp.join(save_path_root, file_name))
         if osp.exists(save_path):
             user_response = input(
-                f'{file_name} already exist. Do you want to cover it? Y/N\n')
+                '%s already exist. Do you want to cover it? Y/N\n' % file_name)
             if user_response.lower() == 'y':
-                print(f'Covering {file_name} to {save_path}')
+                print('Covering %s to %s' % (file_name, save_path))
                 download_file_from_google_drive(file_id, save_path)
             elif user_response.lower() == 'n':
-                print(f'Skipping {file_name}')
+                print('Skipping %s' % file_name)
             else:
                 raise ValueError('Wrong input. Only accpets Y/N.')
         else:
-            print(f'Downloading {file_name} to {save_path}')
+            print('Downloading %s to %s' % (file_name, save_path))
             download_file_from_google_drive(file_id, save_path)
 
         # unzip
         if save_path.endswith('.zip'):
             extracted_path = save_path.replace('.zip', '')
-            print(f'Extract {save_path} to {extracted_path}')
+            print('Extract %s to %s' % (save_path, extracted_path))
             import zipfile
             with zipfile.ZipFile(save_path, 'r') as zip_ref:
                 zip_ref.extractall(extracted_path)
@@ -37,7 +37,7 @@ def download_dataset(dataset, file_ids):
             file_name = file_name.replace('.zip', '')
             subfolder = osp.join(extracted_path, file_name)
             if osp.isdir(subfolder):
-                print(f'Move {subfolder} to {extracted_path}')
+                print('Move %s to %s' % (subfolder, extracted_path))
                 import shutil
                 for path in glob.glob(osp.join(subfolder, '*')):
                     shutil.move(path, extracted_path)

--- a/scripts/data_preparation/extract_images_from_tfrecords.py
+++ b/scripts/data_preparation/extract_images_from_tfrecords.py
@@ -28,11 +28,11 @@ def convert_celeba_tfrecords(tf_file,
         phase = 'train'
     if save_type == 'lmdb':
         save_path = os.path.join(save_root,
-                                 f'celeba_{2**log_resolution}_{phase}.lmdb')
+                                 'celeba_%d_%s.lmdb' % (2 ** log_resolution, phase))
         lmdb_maker = LmdbMaker(save_path)
     elif save_type == 'img':
         save_path = os.path.join(save_root,
-                                 f'celeba_{2**log_resolution}_{phase}')
+                                 'celeba_%d_%s' % (2 ** log_resolution, phase))
     else:
         raise ValueError('Wrong save type.')
 
@@ -59,11 +59,11 @@ def convert_celeba_tfrecords(tf_file,
             img = img[:, :, [2, 1, 0]]
 
             if save_type == 'img':
-                cv2.imwrite(os.path.join(save_path, f'{idx:08d}.png'), img)
+                cv2.imwrite(os.path.join(save_path, '{:08d}.png'.format(idx)), img)
             elif save_type == 'lmdb':
                 _, img_byte = cv2.imencode(
                     '.png', img, [cv2.IMWRITE_PNG_COMPRESSION, compress_level])
-                key = f'{idx:08d}/r{log_resolution:02d}'
+                key = '{:08d}/r{:02d}'.format(idx, log_resolution)
                 lmdb_maker.put(img_byte, key, (h, w, c))
 
             idx += 1
@@ -89,10 +89,10 @@ def convert_ffhq_tfrecords(tf_file,
     """
 
     if save_type == 'lmdb':
-        save_path = os.path.join(save_root, f'ffhq_{2**log_resolution}.lmdb')
+        save_path = os.path.join(save_root, 'ffhq_%d.lmdb' % 2 ** log_resolution)
         lmdb_maker = LmdbMaker(save_path)
     elif save_type == 'img':
-        save_path = os.path.join(save_root, f'ffhq_{2**log_resolution}')
+        save_path = os.path.join(save_root, 'ffhq_%d' % 2 ** log_resolution)
     else:
         raise ValueError('Wrong save type.')
 
@@ -114,11 +114,11 @@ def convert_ffhq_tfrecords(tf_file,
             img = img.transpose(1, 2, 0)
             img = img[:, :, [2, 1, 0]]
             if save_type == 'img':
-                cv2.imwrite(os.path.join(save_path, f'{idx:08d}.png'), img)
+                cv2.imwrite(os.path.join(save_path, '{:08d}.png'.format(idx)), img)
             elif save_type == 'lmdb':
                 _, img_byte = cv2.imencode(
                     '.png', img, [cv2.IMWRITE_PNG_COMPRESSION, compress_level])
-                key = f'{idx:08d}/r{log_resolution:02d}'
+                key = '{:08d}/r{:02d}'.format(idx, log_resolution)
                 lmdb_maker.put(img_byte, key, (h, w, c))
 
             idx += 1
@@ -145,7 +145,7 @@ def make_ffhq_lmdb_from_imgs(folder_path,
 
     if save_type == 'lmdb':
         save_path = os.path.join(save_root,
-                                 f'ffhq_{2**log_resolution}_crop1.2.lmdb')
+                                 'ffhq_%d_crop1.2.lmdb' % 2 ** log_resolution)
         lmdb_maker = LmdbMaker(save_path)
     else:
         raise ValueError('Wrong save type.')
@@ -154,14 +154,14 @@ def make_ffhq_lmdb_from_imgs(folder_path,
 
     img_list = sorted(glob.glob(os.path.join(folder_path, '*')))
     for idx, img_path in enumerate(img_list):
-        print(f'Processing {idx}: ', img_path)
+        print('Processing %d: ' % idx, img_path)
         img = cv2.imread(img_path)
         h, w, c = img.shape
 
         if save_type == 'lmdb':
             _, img_byte = cv2.imencode(
                 '.png', img, [cv2.IMWRITE_PNG_COMPRESSION, compress_level])
-            key = f'{idx:08d}/r{log_resolution:02d}'
+            key = '{:08d}/r{:02d}'.format(idx, log_resolution)
             lmdb_maker.put(img_byte, key, (h, w, c))
 
     if save_type == 'lmdb':

--- a/scripts/data_preparation/extract_subimages.py
+++ b/scripts/data_preparation/extract_subimages.py
@@ -89,9 +89,9 @@ def extract_subimages(opt):
     save_folder = opt['save_folder']
     if not osp.exists(save_folder):
         os.makedirs(save_folder)
-        print(f'mkdir {save_folder} ...')
+        print('mkdir %s ...' % save_folder)
     else:
-        print(f'Folder {save_folder} already exists. Exit.')
+        print('Folder %s already exists. Exit.' % save_folder)
         sys.exit(1)
 
     img_list = list(scandir(input_folder, full_path=True))
@@ -141,7 +141,7 @@ def worker(path, opt):
     elif img.ndim == 3:
         h, w, c = img.shape
     else:
-        raise ValueError(f'Image ndim should be 2 or 3, but got {img.ndim}')
+        raise ValueError('Image ndim should be 2 or 3, but got %d' % img.ndim)
 
     h_space = np.arange(0, h - crop_size + 1, step)
     if h - (h_space[-1] + crop_size) > thresh_size:
@@ -157,10 +157,13 @@ def worker(path, opt):
             cropped_img = img[x:x + crop_size, y:y + crop_size, ...]
             cropped_img = np.ascontiguousarray(cropped_img)
             cv2.imwrite(
-                osp.join(opt['save_folder'],
-                         f'{img_name}_s{index:03d}{extension}'), cropped_img,
+                osp.join(
+                    opt['save_folder'],
+                    '{}_s{:03d}{}'.format(img_name, index, extension)
+                ),
+                cropped_img,
                 [cv2.IMWRITE_PNG_COMPRESSION, opt['compression_level']])
-    process_info = f'Processing {img_name} ...'
+    process_info = 'Processing %s ...' % img_name
     return process_info
 
 

--- a/scripts/data_preparation/generate_meta_info.py
+++ b/scripts/data_preparation/generate_meta_info.py
@@ -23,11 +23,11 @@ def generate_meta_info_div2k():
             elif mode == 'L':
                 n_channel = 1
             else:
-                raise ValueError(f'Unsupported mode {mode}.')
+                raise ValueError('Unsupported mode %s.' % mode)
 
-            info = f'{img_path} ({height},{width},{n_channel})'
+            info = '%s (%d,%d,%d)' % (img_path, height, width, n_channel)
             print(idx + 1, info)
-            f.write(f'{info}\n')
+            f.write(info + '\n')
 
 
 if __name__ == '__main__':

--- a/scripts/data_preparation/regroup_reds_dataset.py
+++ b/scripts/data_preparation/regroup_reds_dataset.py
@@ -20,7 +20,7 @@ def regroup_reds_dataset(train_path, val_path):
     for folder in val_folders:
         new_folder_idx = int(folder.split('/')[-1]) + 240
         os.system(
-            f'cp -r {folder} {os.path.join(train_path, str(new_folder_idx))}')
+            'cp -r %s %s' % (folder, os.path.join(train_path, str(new_folder_idx))))
 
 
 if __name__ == '__main__':

--- a/scripts/download_pretrained_models.py
+++ b/scripts/download_pretrained_models.py
@@ -6,23 +6,22 @@ from basicsr.utils.download_util import download_file_from_google_drive
 
 
 def download_pretrained_models(method, file_ids):
-    save_path_root = f'./experiments/pretrained_models/{method}'
+    save_path_root = './experiments/pretrained_models/%s' % method
     os.makedirs(save_path_root, exist_ok=True)
 
     for file_name, file_id in file_ids.items():
         save_path = osp.abspath(osp.join(save_path_root, file_name))
         if osp.exists(save_path):
-            user_response = input(
-                f'{file_name} already exist. Do you want to cover it? Y/N\n')
+            user_response = input('%s already exist. Do you want to cover it? Y/N\n' % file_name)
             if user_response.lower() == 'y':
-                print(f'Covering {file_name} to {save_path}')
+                print('Covering %s to %s' % (file_name, save_path))
                 download_file_from_google_drive(file_id, save_path)
             elif user_response.lower() == 'n':
-                print(f'Skipping {file_name}')
+                print('Skipping %s' % file_name)
             else:
                 raise ValueError('Wrong input. Only accpets Y/N.')
         else:
-            print(f'Downloading {file_name} to {save_path}')
+            print('Downloading %s to %s' % (file_name, save_path))
             download_file_from_google_drive(file_id, save_path)
 
 

--- a/scripts/metrics/calculate_fid_folder.py
+++ b/scripts/metrics/calculate_fid_folder.py
@@ -63,8 +63,8 @@ def calculate_fid_folder():
     features = features.numpy()
     total_len = features.shape[0]
     features = features[:args.num_sample]
-    print(f'Extracted {total_len} features, '
-          f'use the first {features.shape[0]} features to calculate stats.')
+    print('Extracted %d features, ' % total_len +
+          'use the first %d features to calculate stats.' % features.shape[0])
 
     sample_mean = np.mean(features, 0)
     sample_cov = np.cov(features, rowvar=False)

--- a/scripts/metrics/calculate_fid_stats_from_datasets.py
+++ b/scripts/metrics/calculate_fid_stats_from_datasets.py
@@ -26,7 +26,7 @@ def calculate_stats_from_dataset():
     opt = {}
     opt['name'] = 'FFHQ'
     opt['type'] = 'FFHQDataset'
-    opt['dataroot_gt'] = f'datasets/ffhq/ffhq_{args.size}.lmdb'
+    opt['dataroot_gt'] = 'datasets/ffhq/ffhq_%s.lmdb' % args.size
     opt['io_backend'] = dict(type='lmdb')
     opt['use_hflip'] = False
     opt['mean'] = [0.5, 0.5, 0.5]
@@ -56,12 +56,12 @@ def calculate_stats_from_dataset():
     features = features.numpy()
     total_len = features.shape[0]
     features = features[:args.num_sample]
-    print(f'Extracted {total_len} features, '
-          f'use the first {features.shape[0]} features to calculate stats.')
+    print('Extracted %d features, ' % total_len +
+          'use the first %d features to calculate stats.' % features.shape[0])
     mean = np.mean(features, 0)
     cov = np.cov(features, rowvar=False)
 
-    save_path = f'inception_{opt["name"]}_{args.size}.pth'
+    save_path = 'inception_%s_%s.pth' % (opt["name"], args.size)
     torch.save(
         dict(name=opt['name'], size=args.size, mean=mean, cov=cov),
         save_path,

--- a/scripts/metrics/calculate_lpips.py
+++ b/scripts/metrics/calculate_lpips.py
@@ -46,10 +46,10 @@ def main():
             img_restored.unsqueeze(0).cuda(),
             img_gt.unsqueeze(0).cuda())
 
-        print(f'{i+1:3d}: {basename:25}. \tLPIPS: {lpips_val:.6f}.')
+        print('{:3d}: {:25}. \tLPIPS: {:.6f}.'.format(i + 1, basename, lpips_val))
         lpips_all.append(lpips_val)
 
-    print(f'Average: LPIPS: {sum(lpips_all) / len(lpips_all):.6f}')
+    print('Average: LPIPS: {:.6f}'.format(sum(lpips_all) / len(lpips_all)))
 
 
 if __name__ == '__main__':

--- a/scripts/metrics/calculate_psnr_ssim.py
+++ b/scripts/metrics/calculate_psnr_ssim.py
@@ -80,14 +80,15 @@ def main():
             img_restored * 255,
             crop_border=crop_border,
             input_order='HWC')
-        print(f'{i+1:3d}: {basename:25}. \tPSNR: {psnr:.6f} dB, '
-              f'\tSSIM: {ssim:.6f}')
+        print('{:3d}: {:25}. '.format(i + 1, basename) +
+              '\tPSNR: {:.6f} dB, '.format(psnr) +
+              '\tSSIM: {:.6f}'.format(ssim))
         psnr_all.append(psnr)
         ssim_all.append(ssim)
     print(folder_gt)
     print(folder_restored)
-    print(f'Average: PSNR: {sum(psnr_all) / len(psnr_all):.6f} dB, '
-          f'SSIM: {sum(ssim_all) / len(ssim_all):.6f}')
+    print('Average: PSNR: {:.6f} dB, '.format(sum(psnr_all) / len(psnr_all)) +
+          'SSIM: {:.6f}'.format(sum(ssim_all) / len(ssim_all)))
 
 
 if __name__ == '__main__':

--- a/scripts/metrics/calculate_stylegan2_fid.py
+++ b/scripts/metrics/calculate_stylegan2_fid.py
@@ -60,8 +60,8 @@ def calculate_stylegan2_fid():
     features = features.numpy()
     total_len = features.shape[0]
     features = features[:args.num_sample]
-    print(f'Extracted {total_len} features, '
-          f'use the first {features.shape[0]} features to calculate stats.')
+    print('Extracted %d features, ' % total_len +
+          'use the first %d features to calculate stats.' % features.shape[0])
     sample_mean = np.mean(features, 0)
     sample_cov = np.cov(features, rowvar=False)
 

--- a/scripts/model_conversion/convert_dfdnet.py
+++ b/scripts/model_conversion/convert_dfdnet.py
@@ -18,9 +18,9 @@ def convert_net(ori_net, crt_net):
             else:
                 idx = NAMES['vgg19'].index(crt_k.split('.')[2])
                 if 'weight' in crt_k:
-                    ori_k = f'VggExtract.model.features.{idx}.weight'
+                    ori_k = 'VggExtract.model.features.%s.weight' % idx
                 else:
-                    ori_k = f'VggExtract.model.features.{idx}.bias'
+                    ori_k = 'VggExtract.model.features.%s.bias' % idx
         elif 'attn_blocks' in crt_k:
             if 'left_eye' in crt_k:
                 ori_k = crt_k.replace('attn_blocks.left_eye', 'le')
@@ -35,7 +35,7 @@ def convert_net(ori_net, crt_net):
         elif 'multi_scale_dilation' in crt_k:
             if 'conv_blocks' in crt_k:
                 a, b, c, d, e = crt_k.split('.')
-                ori_k = f'MSDilate.conv{int(c)+1}.{d}.{e}'
+                ori_k = 'MSDilate.conv%s.%s.%s' % (int(c) + 1, d, e)
             else:
                 ori_k = crt_k.replace('multi_scale_dilation.conv_fusion',
                                       'MSDilate.convi')
@@ -55,9 +55,9 @@ def convert_net(ori_net, crt_net):
 
         # replace
         if crt_net[crt_k].size() != ori_net[ori_k].size():
-            raise ValueError('Wrong tensor size: \n'
-                             f'crt_net: {crt_net[crt_k].size()}\n'
-                             f'ori_net: {ori_net[ori_k].size()}')
+            raise ValueError('Wrong tensor size: \n' +
+                             'crt_net: %s\n' % crt_net[crt_k].size() +
+                             'ori_net: %s' % ori_net[ori_k].size())
         else:
             crt_net[crt_k] = ori_net[ori_k]
 

--- a/scripts/model_conversion/convert_models.py
+++ b/scripts/model_conversion/convert_models.py
@@ -42,7 +42,7 @@ def convert_edvr():
             ori_k = crt_k.replace('predeblur.resblock_l', 'pre_deblur.RB_L')
         elif 'predeblur.resblock_l1' in crt_k:
             a, b, c, d, e = crt_k.split('.')
-            ori_k = f'pre_deblur.RB_L1_{int(c)+1}.{d}.{e}'
+            ori_k = 'pre_deblur.RB_L1_%d.%s.%s' % (int(c)+1, d, e)
 
         elif 'conv_l2' in crt_k:
             ori_k = crt_k.replace('conv_l2_', 'fea_L2_conv')
@@ -53,20 +53,20 @@ def convert_edvr():
         elif 'pcd_align.dcn_pack' in crt_k:
             idx = crt_k.split('.l')[1].split('.')[0]
             name = crt_k.split('.l')[1].split('.')[1]
-            ori_k = f'pcd_align.L{idx}_dcnpack.{name}'
+            ori_k = 'pcd_align.L%s_dcnpack.%s' % (idx, name)
             if 'conv_offset' in crt_k:
                 name = name.replace('conv_offset', 'conv_offset_mask')
                 weight_bias = crt_k.split('.l')[1].split('.')[2]
-                ori_k = f'pcd_align.L{idx}_dcnpack.{name}.{weight_bias}'
+                ori_k = 'pcd_align.L%s_dcnpack.%s.%s' % (idx, name, weight_bias)
         elif 'pcd_align.offset_conv' in crt_k:
             a, b, c, d = crt_k.split('.')
             idx = b.split('conv')[1]
             level = c.split('l')[1]
-            ori_k = f'pcd_align.L{level}_offset_conv{idx}.{d}'
+            ori_k = 'pcd_align.L%s_offset_conv%d.%s' % (level, idx, d)
         elif 'pcd_align.feat_conv' in crt_k:
             a, b, c, d = crt_k.split('.')
             level = c.split('l')[1]
-            ori_k = f'pcd_align.L{level}_fea_conv.{d}'
+            ori_k = 'pcd_align.L%s_fea_conv.%s' % (level, d)
         elif 'pcd_align.cas_dcnpack' in crt_k:
             ori_k = crt_k.replace('conv_offset', 'conv_offset_mask')
         elif ('conv_first' in crt_k or 'feature_extraction' in crt_k
@@ -127,7 +127,7 @@ def convert_edsr(ori_net_path, crt_net_path, save_path, num_block=32):
             ori_k = crt_k.replace('conv_first', 'head.0')
             crt_net[crt_k] = ori_net[ori_k]
         elif 'conv_after_body' in crt_k:
-            ori_k = crt_k.replace('conv_after_body', f'body.{num_block}')
+            ori_k = crt_k.replace('conv_after_body', 'body.%d' % num_block)
         elif 'body' in crt_k:
             ori_k = crt_k.replace('conv1', 'body.0').replace('conv2', 'body.2')
         elif 'upsample.0' in crt_k:
@@ -167,10 +167,10 @@ def convert_rcan_model():
 
         elif 'attention' in crt_k:
             a, ai, b, bi, c, ci, d, di, e = crt_k.split('.')
-            ori_k = f'body.{ai}.body.{bi}.body.{ci}.conv_du.{int(di)-1}.{e}'
+            ori_k = 'body.%s.body.%s.body.%s.conv_du.%d.%s' % (ai, bi, ci, int(di) - 1, e)
         elif 'rcab' in crt_k:
             a, ai, b, bi, c, ci, d = crt_k.split('.')
-            ori_k = f'body.{ai}.body.{bi}.body.{ci}.{d}'
+            ori_k = 'body.%s.body.%s.body.%s.%s' % (ai, bi, ci, d)
         elif 'body' in crt_k:
             ori_k = crt_k.replace('conv.', 'body.20.')
         else:

--- a/scripts/model_conversion/convert_stylegan.py
+++ b/scripts/model_conversion/convert_stylegan.py
@@ -39,9 +39,9 @@ def convert_net_g(ori_net, crt_net):
 
         # replace
         if crt_net[crt_k].size() != ori_net[ori_k].size():
-            raise ValueError('Wrong tensor size: \n'
-                             f'crt_net: {crt_net[crt_k].size()}\n'
-                             f'ori_net: {ori_net[ori_k].size()}')
+            raise ValueError('Wrong tensor size: \n' +
+                             'crt_net: %s\n' % crt_net[crt_k].size() +
+                             'ori_net: %s' % ori_net[ori_k].size())
         else:
             crt_net[crt_k] = ori_net[ori_k]
 
@@ -59,9 +59,9 @@ def convert_net_d(ori_net, crt_net):
 
         # replace
         if crt_net[crt_k].size() != ori_net[ori_k].size():
-            raise ValueError('Wrong tensor size: \n'
-                             f'crt_net: {crt_net[crt_k].size()}\n'
-                             f'ori_net: {ori_net[ori_k].size()}')
+            raise ValueError('Wrong tensor size: \n' +
+                             'crt_net: %s\n' % crt_net[crt_k].size() +
+                             'ori_net: %s' % ori_net[ori_k].size())
         else:
             crt_net[crt_k] = ori_net[ori_k]
     return crt_net

--- a/scripts/publish_models.py
+++ b/scripts/publish_models.py
@@ -8,12 +8,12 @@ from torch.serialization import _is_zipfile, _open_file_like
 def update_sha(paths):
     print('# Update sha ...')
     for idx, path in enumerate(paths):
-        print(f'{idx+1:03d}: Processing {path}')
+        print('{:03d}: Processing {}'.format(idx + 1, path))
         net = torch.load(path, map_location=torch.device('cpu'))
         basename = osp.basename(path)
         if 'params' not in net and 'params_ema' not in net:
-            raise ValueError(f'Please check! Model {basename} does not '
-                             f"have 'params'/'params_ema' key.")
+            raise ValueError('Please check! Model ' + basename +
+                             ' does not have "params"/"params_ema" key.')
         else:
             if '-' in basename:
                 # check whether the sha is the latest
@@ -21,13 +21,13 @@ def update_sha(paths):
                 new_sha = subprocess.check_output(['sha256sum',
                                                    path]).decode()[:8]
                 if old_sha != new_sha:
-                    final_file = path.split('-')[0] + f'-{new_sha}.pth'
-                    print(f'\tSave from {path} to {final_file}')
+                    final_file = path.split('-')[0] + '-' + new_sha + '.pth'
+                    print('\tSave from %s to %s' % (path, final_file))
                     subprocess.Popen(['mv', path, final_file])
             else:
                 sha = subprocess.check_output(['sha256sum', path]).decode()[:8]
-                final_file = path.split('.pth')[0] + f'-{sha}.pth'
-                print(f'\tSave from {path} to {final_file}')
+                final_file = path.split('.pth')[0] + '-' + sha + '.pth'
+                print('\tSave from %s to %s' % (path, final_file))
                 subprocess.Popen(['mv', path, final_file])
 
 
@@ -40,7 +40,7 @@ def convert_to_backward_compatible_models(paths):
     """
     print('# Convert to backward compatible pth files ...')
     for idx, path in enumerate(paths):
-        print(f'{idx+1:03d}: Processing {path}')
+        print('{:03d}: Processing {}'.format(idx + 1, path))
         flag_need_conversion = False
         with _open_file_like(path, 'rb') as opened_file:
             if _is_zipfile(opened_file):

--- a/tests/test_ffhq_dataset.py
+++ b/tests/test_ffhq_dataset.py
@@ -50,7 +50,7 @@ def main():
         print(gt_path)
         torchvision.utils.save_image(
             gt,
-            f'tmp/gt_{i:03d}.png',
+            'tmp/gt_{:03d}.png'.format(i),
             nrow=nrow,
             padding=padding,
             normalize=True,

--- a/tests/test_paired_image_dataset.py
+++ b/tests/test_paired_image_dataset.py
@@ -66,13 +66,13 @@ def main(mode='folder'):
         print(lq_path, gt_path)
         torchvision.utils.save_image(
             lq,
-            f'tmp/lq_{i:03d}.png',
+            'tmp/lq_{:03d}.png'.format(i),
             nrow=nrow,
             padding=padding,
             normalize=False)
         torchvision.utils.save_image(
             gt,
-            f'tmp/gt_{i:03d}.png',
+            'tmp/gt_{:03d}.png'.format(i),
             nrow=nrow,
             padding=padding,
             normalize=False)

--- a/tests/test_reds_dataset.py
+++ b/tests/test_reds_dataset.py
@@ -67,13 +67,13 @@ def main(mode='folder'):
         for j in range(opt['num_frame']):
             torchvision.utils.save_image(
                 lq[:, j, :, :, :],
-                f'tmp/lq_{i:03d}_frame{j}.png',
+                'tmp/lq_{:03d}_frame{:d}.png'.format(i, j),
                 nrow=nrow,
                 padding=padding,
                 normalize=False)
         torchvision.utils.save_image(
             gt,
-            f'tmp/gt_{i:03d}.png',
+            'tmp/gt_{:03d}.png'.format(i),
             nrow=nrow,
             padding=padding,
             normalize=False)

--- a/tests/test_vimeo90k_dataset.py
+++ b/tests/test_vimeo90k_dataset.py
@@ -63,13 +63,13 @@ def main(mode='folder'):
         for j in range(opt['num_frame']):
             torchvision.utils.save_image(
                 lq[:, j, :, :, :],
-                f'tmp/lq_{i:03d}_frame{j}.png',
+                'tmp/lq_{:03d}_frame{:d}.png'.format(i, j),
                 nrow=nrow,
                 padding=padding,
                 normalize=False)
         torchvision.utils.save_image(
             gt,
-            f'tmp/gt_{i:03d}.png',
+            'tmp/gt_{:03d}.png'.format(i),
             nrow=nrow,
             padding=padding,
             normalize=False)


### PR DESCRIPTION
Right now, the codebase supports Python 3.6.0 and newer, with this pull request it will also support Python 3.5.

There isn't any specific reason for adding support other than why not considering the only change needed to be made was to how strings were formatted.

I replaced f-strings with % formatting. If specific formatting is necessary it used string templating via `.format()`.

The % formatting needed to specify how to display it (e.g. %d for int, %s for string, e.t.c). I used what I could tell was appropriate but due to the sheer amount of formats I had to replace, I might have made a mistake or two on one of them, which may cause an unexpected exception being raised, so reviewing the format value I used would be necessary before merging.

While doing this I have fixed a few small stuff in relation to the string being formatted in various ways. Some of them I even made it so string formatting wasn't necessary at all, reformatted the line (or its neighboring lines) a bit to better accommodate it, or fixed a few mistakes in the string itself (like the variable name being in the string next to the variable).

EDIT:

I should also note, some lines have had to be widened beyond the 79 line width that your flake8 test is doing. My IDE (PyCharm) uses a 120 line width which in my opinion is just right, so if need be those may need to be fixed/changed up.

This also means it is safe to add a GitHub Workflow file for your pylint test on Python versions 3.5-3.9, not just 3.8.