### PR TITLE
Fix to the wandb and tensorboard sync issue (#323)

### DIFF
--- a/basicsr/train.py
+++ b/basicsr/train.py
@@ -63,16 +63,16 @@ def init_loggers(opt):
     logger.info(get_env_info())
     logger.info(dict2str(opt))
 
-    # initialize tensorboard logger and wandb logger
-    tb_logger = None
-    if opt['logger'].get('use_tb_logger') and 'debug' not in opt['name']:
-        tb_logger = init_tb_logger(log_dir=osp.join('tb_logger', opt['name']))
+    # initialize wandb logger first and then tensorboard logger to solve wandb logging problems:
     if (opt['logger'].get('wandb')
             is not None) and (opt['logger']['wandb'].get('project')
                               is not None) and ('debug' not in opt['name']):
         assert opt['logger'].get('use_tb_logger') is True, (
             'should turn on tensorboard when using wandb')
         init_wandb_logger(opt)
+    tb_logger = None
+    if opt['logger'].get('use_tb_logger') and 'debug' not in opt['name']:
+        tb_logger = init_tb_logger(log_dir=osp.join('tb_logger', opt['name']))
     return logger, tb_logger
 
 

--- a/basicsr/train.py
+++ b/basicsr/train.py
@@ -63,7 +63,7 @@ def init_loggers(opt):
     logger.info(get_env_info())
     logger.info(dict2str(opt))
 
-    # initialize wandb logger first and then tensorboard logger to solve wandb logging problems:
+    # initialize wandb logger before tensorboard logger to allow proper sync:
     if (opt['logger'].get('wandb')
             is not None) and (opt['logger']['wandb'].get('project')
                               is not None) and ('debug' not in opt['name']):


### PR DESCRIPTION
- initialize the wandb logger before the tensorboard logger, to solve the wandb logging problem (solution inspired by this issue: https://github.com/wandb/client/issues/493)

This solves issue #323 