### PR TITLE
Models can be logged as W&B artifacts.

### DIFF
--- a/basicsr/models/base_model.py
+++ b/basicsr/models/base_model.py
@@ -192,6 +192,12 @@ class BaseModel():
     def get_current_learning_rate(self):
         return [param_group['lr'] for param_group in self.optimizers[0].param_groups]
 
+    def get_save_path(self, net_label, current_iter):
+        if current_iter == -1:
+            current_iter = 'latest'
+        save_filename = f'{net_label}_{current_iter}.pth'
+        return os.path.join(self.opt['path']['models'], save_filename)
+
     @master_only
     def save_network(self, net, net_label, current_iter, param_key='params'):
         """Save networks.
@@ -203,10 +209,7 @@ class BaseModel():
             param_key (str | list[str]): The parameter key(s) to save network.
                 Default: 'params'.
         """
-        if current_iter == -1:
-            current_iter = 'latest'
-        save_filename = f'{net_label}_{current_iter}.pth'
-        save_path = os.path.join(self.opt['path']['models'], save_filename)
+        save_path = self.get_save_path(net_label, current_iter)
 
         net = net if isinstance(net, list) else [net]
         param_key = param_key if isinstance(param_key, list) else [param_key]

--- a/basicsr/utils/__init__.py
+++ b/basicsr/utils/__init__.py
@@ -2,7 +2,7 @@ from .diffjpeg import DiffJPEG
 from .file_client import FileClient
 from .img_process_util import USMSharp, usm_sharp
 from .img_util import crop_border, imfrombytes, img2tensor, imwrite, tensor2img
-from .logger import AvgTimer, MessageLogger, get_env_info, get_root_logger, init_tb_logger, init_wandb_logger
+from .logger import AvgTimer, MessageLogger, get_env_info, get_root_logger, init_tb_logger, init_wandb_logger, wandb_enabled, log_artifact
 from .misc import check_resume, get_time_str, make_exp_dirs, mkdir_and_rename, scandir, set_random_seed, sizeof_fmt
 
 __all__ = [
@@ -19,6 +19,8 @@ __all__ = [
     'AvgTimer',
     'init_tb_logger',
     'init_wandb_logger',
+    'wandb_enabled',
+    'log_artifact',
     'get_root_logger',
     'get_env_info',
     # misc.py


### PR DESCRIPTION
Upload is controlled by a new option `logger`/`wandb`/`log_model`. When
enabled, model files are uploaded to W&B as artifacts attached to the
current run, at the frequency specified by `save_checkpoint_freq`.

I'm using this feature for several purposes:
- Centralized storage of models being trained in various locations.
- Decoupling of training and testing. I usually upload models as training
progresses, while a job running in a different computer downloads them
and performs arbitrary metrics / evaluation tasks.