### PR TITLE
add a script for creating a compile_commands.json

### DIFF
--- a/scripts/create_compile_commands.py
+++ b/scripts/create_compile_commands.py
@@ -1,0 +1,20 @@
+import os
+
+
+def create_compile_commands(path='build'):
+    path = os.path.realpath(path)
+    os.makedirs(path, exist_ok=True)
+    ninja_files = []
+    for root, dirs, files in os.walk('./'):
+        for file in files:
+            if file == "build.ninja":
+                ninja_files.append(os.path.join(root, file))
+    assert len(ninja_files) == 1, "The number of 'build.ninja' file must be 1."
+
+    real_path = os.path.realpath(ninja_files[0])
+
+    output_path = os.path.join(path, "compile_commands.json")
+    result = os.popen(f"ninja -f {real_path} -t compdb")
+    with open(output_path, 'w+') as f:
+        f.write(result.read())
+    print(f"Saved compile_commands.json at {os.path.relpath(output_path)}")

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ import subprocess
 import time
 import torch
 from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension
+from scripts.create_compile_commands import create_compile_commands
 
 version_file = 'basicsr/version.py'
 
@@ -164,3 +165,5 @@ if __name__ == '__main__':
         ext_modules=ext_modules,
         cmdclass={'build_ext': BuildExtension},
         zip_safe=False)
+
+create_compile_commands('build')


### PR DESCRIPTION
When I wrote a c++ extension, I can't get intellisense and there were a lot of annoying warnings, so I added a script to create a compile_commands.json. In this way I can get intellisense about c++ with the help of clangd. Here is a demo showing how this method works. https://gitee.com/rolfma/py-torch-extension, I'm a big fan of yours, and I sincerely hope to make my contribution to BaiscSR.